### PR TITLE
Fix always redirecting to home from a concrete link

### DIFF
--- a/apps/cyberrangecz-platform/src/app/services/role.service.ts
+++ b/apps/cyberrangecz-platform/src/app/services/role.service.ts
@@ -1,6 +1,8 @@
 import { inject, Injectable } from '@angular/core';
 import { SentinelAuthService } from '@sentinel/auth';
 import { PortalConfig } from '@crczp/utils';
+import { Observable } from 'rxjs';
+import { map, tap } from 'rxjs/operators';
 
 export type RoleKey =
     | 'uagAdmin'
@@ -55,19 +57,88 @@ export class RoleService {
         });
     }
 
+    /**
+     * @param roleKey role to check
+     * @returns true if the user has the role
+     */
     hasRole(roleKey: RoleKey) {
         return this.rolesDict.has(this.config.roleMapping[roleKey]);
     }
 
+    /**
+     * @param roles roles to check
+     * @returns true if the user has any (at least one) of the roles
+     */
     hasAny(roles: RoleKey[]) {
         return roles
             .map((roleKey) => this.config.roleMapping[roleKey])
             .some((role) => this.hasRole(role));
     }
 
+    /**
+     * @param roles roles to check
+     * @returns true if the user has all specified roles
+     */
     hasAll(roles: RoleKey[]) {
         return !roles
             .map((roleKey) => this.config.roleMapping[roleKey])
             .some((role) => !this.hasRole(role));
+    }
+
+    /**
+     * Checks if the user has the specified role
+     * Use this method when you need to wait for the user to be loaded
+     * or listen for changes
+     *
+     * @param roleKey role to check
+     * @returns observable that emits true if the user has the role
+     */
+    hasRole$(roleKey: RoleKey): Observable<boolean> {
+        return this.authService.activeUser$.pipe(
+            tap((user) => {
+                const mappedRole = this.config.roleMapping[roleKey];
+                console.group(`Role Check Debug - ${roleKey}`);
+                console.log(
+                    `Checking role ${roleKey} mapped to ${mappedRole}:`,
+                    user?.roles,
+                );
+                console.log(
+                    'Check result:',
+                    user?.roles.some((role) => role.roleType === mappedRole),
+                );
+                console.groupEnd();
+            }),
+            map((user) => {
+                if (!user) {
+                    return false;
+                }
+                const mappedRole = this.config.roleMapping[roleKey];
+                return user.roles.some((role) => role.roleType === mappedRole);
+            }),
+        );
+    }
+
+    /**
+     * Checks if the user has any of the specified roles
+     * Use this method when you need to wait for the user to be loaded
+     * or listen for changes
+     *
+     * @param roleKeys roles to check
+     * @returns observable that emits true if the user has any of the roles
+     */
+    hasAny$(roleKeys: RoleKey[]): Observable<boolean> {
+        return this.authService.activeUser$.pipe(
+            map((user) => {
+                if (!user) {
+                    return false;
+                }
+                const mappedRoles = roleKeys.map(
+                    (roleKey) => this.config.roleMapping[roleKey],
+                );
+                return user.roles.some((role) =>
+                    mappedRoles.includes(role.roleType),
+                );
+            }),
+        );
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@crczp/platform",
-    "version": "2.0.1",
+    "version": "2.0.2",
     "license": "MIT",
     "private": true,
     "dependencies": {


### PR DESCRIPTION
The root cause was that the guard builder for roles was using `sentinelAuthGuard` instead of `sentinelAuthGuardWithLogin` internally. This works fine after the user is logged in, but for an initial load this was not doing auth before checking the role, which meant the user got always sent to `/login` where SSO automatically logged in and redirected to `/home`.

This means, when a user accessed for example `/pool` without having a previous session (for example clicking on a link), he would aways end up on '/home'