### PR TITLE
Fix guacamole url

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@crczp/platform",
-    "version": "2.3.2",
+    "version": "2.3.3",
     "license": "MIT",
     "private": true,
     "dependencies": {


### PR DESCRIPTION
- Added deriving of WSS socket url from config for guacamole service

I chose to keep guacamole base with http, as this will be later on used in other endpoints and changes could confuse users