### PR TITLE
Fix adaptive training

### DIFF
--- a/apps/cyberrangecz-platform/src/app/modules/training-agenda/adaptive-instance-routing.module.ts
+++ b/apps/cyberrangecz-platform/src/app/modules/training-agenda/adaptive-instance-routing.module.ts
@@ -71,7 +71,7 @@ const routes: ValidRouterConfig<'adaptive-instance'> = [
             title: Routing.Resolvers.TrainingInstance
                 .adaptiveInstanceTitleResolver,
         },
-        loadChildren: () =>
+        loadComponent: () =>
             import('@crczp/training-agenda/adaptive-instance-summary').then(
                 (m) => m.AdaptiveInstanceSummaryComponent,
             ),
@@ -87,7 +87,7 @@ const routes: ValidRouterConfig<'adaptive-instance'> = [
             title: Routing.Resolvers.TrainingInstance
                 .adaptiveInstanceTitleResolver,
         },
-        loadChildren: () =>
+        loadComponent: () =>
             import('@crczp/training-agenda/adaptive-instance-results').then(
                 (m) => m.AdaptiveInstanceResultsComponent,
             ),
@@ -103,7 +103,7 @@ const routes: ValidRouterConfig<'adaptive-instance'> = [
             title: Routing.Resolvers.TrainingInstance
                 .adaptiveInstanceTitleResolver,
         },
-        loadChildren: () =>
+        loadComponent: () =>
             import('@crczp/training-agenda/adaptive-instance-progress').then(
                 (m) => m.AdaptiveInstanceProgressComponent,
             ),
@@ -119,7 +119,7 @@ const routes: ValidRouterConfig<'adaptive-instance'> = [
             title: Routing.Resolvers.TrainingInstance
                 .adaptiveInstanceTitleResolver,
         },
-        loadChildren: () =>
+        loadComponent: () =>
             import('@crczp/training-agenda/adaptive-instance-runs').then(
                 (m) => m.AdaptiveInstanceRunsComponent,
             ),

--- a/libs/agenda/training-agenda/run-detail/components/level/abstract-level-with-flag/subcomponents/abstract-flag-level/abstract-flag-level.component.html
+++ b/libs/agenda/training-agenda/run-detail/components/level/abstract-level-with-flag/subcomponents/abstract-flag-level/abstract-flag-level.component.html
@@ -18,12 +18,14 @@
     (runService.runInfo$.observeProperty().isBacktracked.$() | async)) {
         <button
             (click)="runService.nextLevel()"
+            [disabled]="isLoading()"
             class="next-button"
             mat-raised-button>
             {{ lastLevelDisplayed && !runService.runInfo.isBacktracked ? "Finish" : "Next" }}
         </button>
     } @else {
         <crczp-floating-answer-form
+            [isLoading]="isLoading()"
             (answerSubmit)="answerSubmitted.emit($event)"
             [buttonLabel]="lastLevelDisplayed ? 'Finish' : 'Submit'"
         >

--- a/libs/agenda/training-agenda/run-detail/components/level/abstract-level-with-flag/subcomponents/abstract-flag-level/abstract-flag-level.component.ts
+++ b/libs/agenda/training-agenda/run-detail/components/level/abstract-level-with-flag/subcomponents/abstract-flag-level/abstract-flag-level.component.ts
@@ -28,6 +28,7 @@ import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
     ],
 })
 export class AbstractFlagLevelComponent {
+    readonly isLoading = input(false);
     readonly hints = input<Hint[]>([]);
     readonly levelContent = input.required<string>();
     readonly solutionContent = input<string | null>(null);

--- a/libs/agenda/training-agenda/run-detail/components/level/abstract-level-with-flag/subcomponents/answer-floating-form/floating-answer-form.component.html
+++ b/libs/agenda/training-agenda/run-detail/components/level/abstract-level-with-flag/subcomponents/answer-floating-form/floating-answer-form.component.html
@@ -29,6 +29,7 @@
             </mat-form-field>
             <button
                 (click)="submitAnswer()"
+                [disabled]="isLoading()"
                 class="submit-button"
                 color="primary"
                 mat-flat-button

--- a/libs/agenda/training-agenda/run-detail/components/level/abstract-level-with-flag/subcomponents/answer-floating-form/floating-answer-form.component.ts
+++ b/libs/agenda/training-agenda/run-detail/components/level/abstract-level-with-flag/subcomponents/answer-floating-form/floating-answer-form.component.ts
@@ -20,6 +20,8 @@ import { FormsModule } from '@angular/forms';
     ],
 })
 export class FloatingAnswerFormComponent {
+    isLoading = input<boolean>(false);
+
     buttonLabel = input<string>('Submit');
 
     answerSubmit = output<string>();

--- a/libs/agenda/training-agenda/run-detail/components/level/abstract-level.component.ts
+++ b/libs/agenda/training-agenda/run-detail/components/level/abstract-level.component.ts
@@ -73,7 +73,7 @@ export class AbstractLevelComponent implements OnInit, AfterViewInit {
     protected readonly stepperSteps = signal<StepperItem[]>([]);
     protected readonly stepperSelectedIndex = signal<number | null>(null);
     protected readonly stepperLastIndex = signal<number | null>(null);
-    protected stepperHeight = signal<number>(148);
+    protected readonly stepperHeight = signal<number>(148);
 
     constructor() {
         this.displayedLevelTitle$ = this.runService.runInfo$

--- a/libs/agenda/training-agenda/run-detail/components/level/access-level/access-level.component.html
+++ b/libs/agenda/training-agenda/run-detail/components/level/access-level/access-level.component.html
@@ -1,4 +1,5 @@
 <crczp-abstract-flag-level
+    [isLoading]="isLoading()"
     (answerSubmitted)="onAnswerSubmitted($event)"
     [levelContent]="levelContent$ | async"
 />

--- a/libs/agenda/training-agenda/run-detail/components/level/access-level/generic-access-level.component.ts
+++ b/libs/agenda/training-agenda/run-detail/components/level/access-level/generic-access-level.component.ts
@@ -1,14 +1,30 @@
-import { of } from 'rxjs';
+import { combineLatest, of } from 'rxjs';
 import { AbstractAccessLevelService } from '../../../services/training-run/level/access/abstract-access-level.service';
 import { AbstractTrainingRunService } from '../../../services/training-run/abstract-training-run.service';
+import { signal } from '@angular/core';
+import { map } from 'rxjs/operators';
 
 export abstract class GenericAccessLevelComponent {
     protected readonly of = of;
 
+    protected readonly isLoading = signal(false);
+
     protected constructor(
         protected readonly runService: AbstractTrainingRunService,
         protected readonly accessLevelService: AbstractAccessLevelService,
-    ) {}
+    ) {
+        combineLatest([
+            this.runService.isLoading$,
+            this.accessLevelService.isLoading$,
+        ])
+            .pipe(
+                map(
+                    ([isSubmittingAnswer, isLoadingLevel]) =>
+                        isSubmittingAnswer || isLoadingLevel,
+                ),
+            )
+            .subscribe((loading) => this.isLoading.set(loading));
+    }
 
     /**
      * Calls service to check whether the passkey is correct

--- a/libs/agenda/training-agenda/run-detail/components/level/assessment-level/assessment-level.component.html
+++ b/libs/agenda/training-agenda/run-detail/components/level/assessment-level/assessment-level.component.html
@@ -19,6 +19,7 @@
     @if (isBacktracked) {
         <button
             (click)="this.runService.nextLevel()"
+            [disabled]="isLoading()"
             class="confirm-button"
             mat-raised-button>
             Next
@@ -26,7 +27,7 @@
     } @else {
         <button
             (click)="submit()"
-            [disabled]="!canSubmit"
+            [disabled]="!canSubmit || isLoading()"
             class="confirm-button"
             mat-flat-button>
             {{

--- a/libs/agenda/training-agenda/run-detail/components/level/info-level/info-level.component.html
+++ b/libs/agenda/training-agenda/run-detail/components/level/info-level/info-level.component.html
@@ -4,6 +4,7 @@
     </div>
     <button
         (click)="runService.nextLevel()"
+        [disabled]="runService.isLoading$ | async"
         class="next-button"
         mat-raised-button>
         {{ (runService.runInfo$.observeProperty().isLastLevel.$() | async) ? "Finish" : "Next" }}

--- a/libs/agenda/training-agenda/run-detail/components/level/info-level/info-level.component.ts
+++ b/libs/agenda/training-agenda/run-detail/components/level/info-level/info-level.component.ts
@@ -6,6 +6,7 @@ import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { InfoLevel, InfoPhase } from '@crczp/training-model';
 import { AsyncPipe } from '@angular/common';
+import { isLoading } from '@sentinel/common/utils';
 
 @Component({
     selector: 'crczp-info-level',
@@ -28,4 +29,6 @@ export class InfoLevelComponent {
             ),
         );
     }
+
+    protected readonly isLoading = isLoading;
 }

--- a/libs/agenda/training-agenda/run-detail/components/level/questionnaire-phase/questionnaire-level.component.html
+++ b/libs/agenda/training-agenda/run-detail/components/level/questionnaire-phase/questionnaire-level.component.html
@@ -70,6 +70,7 @@
     @if (isBacktracked) {
         <button
             (click)="onNext()"
+            [disabled]="isLoading()"
             class="confirm-button"
             mat-raised-button>
             Next
@@ -77,7 +78,7 @@
     } @else {
         <button
             (click)="submit()"
-            [disabled]="!canSubmit()"
+            [disabled]="!canSubmit() || isLoading()"
             class="confirm-button"
             mat-flat-button>
             {{ isLast ? "Finish" : "Submit" }}

--- a/libs/agenda/training-agenda/run-detail/components/level/training-level/generic-training-level.component.html
+++ b/libs/agenda/training-agenda/run-detail/components/level/training-level/generic-training-level.component.html
@@ -1,4 +1,5 @@
 <crczp-abstract-flag-level
+    [isLoading]="isLoading()"
     (answerSubmitted)="onAnswerSubmitted($event)"
     [hints]="hints$ | async"
     [levelContent]="levelContent$ | async"

--- a/libs/agenda/training-agenda/run-detail/services/training-run/level/access/adaptive-access-level.service.ts
+++ b/libs/agenda/training-agenda/run-detail/services/training-run/level/access/adaptive-access-level.service.ts
@@ -1,12 +1,12 @@
 import { inject, Injectable } from '@angular/core';
 import { AdaptiveRunApi } from '@crczp/training-api';
 import { AbstractAccessLevelService } from './abstract-access-level.service';
-import { AnswerCheckResult } from '@crczp/training-model';
 import { Observable } from 'rxjs';
-import { take } from 'rxjs/operators';
+import { map, take } from 'rxjs/operators';
 import { MatDialog } from '@angular/material/dialog';
 import { NotificationService } from '@crczp/utils';
 import { AbstractTrainingRunService } from '../../abstract-training-run.service';
+import { AnswerCheckResult } from '@crczp/training-model';
 
 @Injectable()
 export class AdaptiveAccessLevelService extends AbstractAccessLevelService {
@@ -22,7 +22,12 @@ export class AdaptiveAccessLevelService extends AbstractAccessLevelService {
 
     callApiToSubmitAnswer(answer: string): Observable<AnswerCheckResult> {
         return this.api
-            .isCorrectAnswer(this.runService.runInfo.trainingRunId, answer)
-            .pipe(take(1));
+            .isCorrectPasskey(this.runService.runInfo.trainingRunId, answer)
+            .pipe(
+                take(1),
+                map((result) => {
+                    return new AnswerCheckResult(result);
+                }),
+            );
     }
 }

--- a/libs/agenda/training-agenda/run-detail/services/training-run/level/access/training/abstract-training-level.service.ts
+++ b/libs/agenda/training-agenda/run-detail/services/training-run/level/access/training/abstract-training-level.service.ts
@@ -105,21 +105,23 @@ export abstract class AbstractTrainingLevelService extends AbstractAccessLevelSe
     }
 
     private revealSolution(): void {
-        this.callApiToRevealSolution().subscribe((solution) => {
-            const trainingLevel = this.displayedTrainingLevel;
-            this.runService.updateRunInfo({
-                levels: this.runService.runInfo.levels.map((level) => {
-                    if (level.id === trainingLevel.id) {
-                        if (level instanceof TrainingLevel) {
-                            level.solution = solution;
+        this.loadingTracker
+            .trackRequest(() => this.callApiToRevealSolution())
+            .subscribe((solution) => {
+                const trainingLevel = this.displayedTrainingLevel;
+                this.runService.updateRunInfo({
+                    levels: this.runService.runInfo.levels.map((level) => {
+                        if (level.id === trainingLevel.id) {
+                            if (level instanceof TrainingLevel) {
+                                level.solution = solution;
+                            }
+                            if (level instanceof TrainingPhase) {
+                                level.currentTask.solution = solution;
+                            }
                         }
-                        if (level instanceof TrainingPhase) {
-                            level.currentTask.solution = solution;
-                        }
-                    }
-                    return level;
-                }),
+                        return level;
+                    }),
+                });
             });
-        });
     }
 }

--- a/libs/agenda/training-agenda/run-detail/services/training-run/level/assessment/adaptive-assessment-level.service.ts
+++ b/libs/agenda/training-agenda/run-detail/services/training-run/level/assessment/adaptive-assessment-level.service.ts
@@ -2,6 +2,7 @@ import { inject, Injectable } from '@angular/core';
 import { AdaptiveRunApi } from '@crczp/training-api';
 import { QuestionAnswer } from '@crczp/training-model';
 import { AbstractTrainingRunService } from '../../abstract-training-run.service';
+import { LoadingTracker } from '@crczp/utils';
 
 /**
  * Handles events and actions specific for assessment level in training run
@@ -11,12 +12,15 @@ export class AdaptiveAssessmentLevelService {
     private api = inject(AdaptiveRunApi);
     private runningTrainingRunService = inject(AbstractTrainingRunService);
 
+    protected readonly loadingTracker = new LoadingTracker();
+    public readonly isLoading$ = this.loadingTracker.isLoading$;
+
     submit(answers: QuestionAnswer[]): void {
-        this.api
+        this.loadingTracker.trackRequest(()=>this.api
             .evaluateQuestionnaire(
                 this.runningTrainingRunService.runInfo.trainingRunId,
                 answers,
-            )
+            ))
             .subscribe(() => {
                 this.runningTrainingRunService.updateRunInfo({
                     isCurrentLevelAnswered: true,

--- a/libs/agenda/training-agenda/run-detail/services/training-run/level/assessment/linear-assessment-level.service.ts
+++ b/libs/agenda/training-agenda/run-detail/services/training-run/level/assessment/linear-assessment-level.service.ts
@@ -2,6 +2,7 @@ import { inject, Injectable } from '@angular/core';
 import { LinearRunApi } from '@crczp/training-api';
 import { Question } from '@crczp/training-model';
 import { AbstractTrainingRunService } from '../../abstract-training-run.service';
+import { LoadingTracker } from '@crczp/utils';
 
 /**
  * Handles events and actions specific for assessment level in training run
@@ -11,16 +12,19 @@ export class LinearAssessmentLevelService {
     private api = inject(LinearRunApi);
     private runningTrainingRunService = inject(AbstractTrainingRunService);
 
+    protected readonly loadingTracker = new LoadingTracker();
+    public readonly isLoading$ = this.loadingTracker.isLoading$;
+
     /**
      * Submit answers entered by trainee
      * @param answers answers entered by user
      */
     submit(answers: Question[]): void {
-        this.api
+        this.loadingTracker.trackRequest(()=>this.api
             .submitAnswers(
                 this.runningTrainingRunService.runInfo.trainingRunId,
                 answers,
-            )
+            ))
             .subscribe(() => {
                 this.runningTrainingRunService.updateRunInfo({
                     isCurrentLevelAnswered: true,

--- a/libs/components/src/adaptive-instance-simulator/transition-visualization/api/adaptive-transition-visualization-api.service.ts
+++ b/libs/components/src/adaptive-instance-simulator/transition-visualization/api/adaptive-transition-visualization-api.service.ts
@@ -13,7 +13,7 @@ import { PortalConfig } from '@crczp/utils';
 export class AdaptiveTransitionVisualizationApi {
     private readonly http = inject(HttpClient);
 
-    private readonly apiUrl = inject(PortalConfig).basePaths.linearTraining;
+    private readonly apiUrl = inject(PortalConfig).basePaths.adaptiveTraining;
 
     getDataForTrainingInstance(
         trainingInstanceId: number,

--- a/libs/model/training-model/src/enums/abstract-level-type.enum.ts
+++ b/libs/model/training-model/src/enums/abstract-level-type.enum.ts
@@ -1,6 +1,6 @@
 export enum AbstractLevelTypeEnum {
-    Access = 'access',
-    Training = 'training',
-    Assessment = 'assessment',
-    Info = 'info',
+    Access = 'linear_access',
+    Training = 'linear_training',
+    Assessment = 'linear_assessment',
+    Info = 'linear_info',
 }

--- a/libs/model/training-model/src/enums/abstract-phase-type.enum.ts
+++ b/libs/model/training-model/src/enums/abstract-phase-type.enum.ts
@@ -1,7 +1,7 @@
 export enum AbstractPhaseTypeEnum {
-    Info = 'info',
-    Training = 'training',
-    Access = 'access',
-    Questionnaire = 'questionnaire',
-    Task = 'task',
+    Info = 'adaptive_info',
+    Training = 'adaptive_training',
+    Access = 'adaptive_access',
+    Questionnaire = 'adaptive_questionnaire',
+    Task = 'adaptive_task',
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@crczp/platform",
-    "version": "2.5.0",
+    "version": "2.5.1",
     "license": "MIT",
     "private": true,
     "dependencies": {


### PR DESCRIPTION
- Fixed incorrect routing configuration by changing `loadChildren` to `loadComponent`
- Renamed `AbstractLevelTypeEnum` and `AbstractPhaseTypeEnum` values to add `linear_` and `adaptive_` prefixes, fixing name overlap that caused incorrect level component resolution
- Added loading tracker to dynamically disable bottom controls while loading and prevent duplicate API calls
- Fixed questionnaire initialization to check state after init, allowing immediate submission when no required questions exist
- Fixed incorrect API service usage in adaptive training (corrected base path and endpoint method calls)