### PR TITLE
Fix observable not firing when editing instance

### DIFF
--- a/libs/agenda/training-agenda/instance-edit/services/state/edit/common-training-instance-edit.service.ts
+++ b/libs/agenda/training-agenda/instance-edit/services/state/edit/common-training-instance-edit.service.ts
@@ -238,9 +238,8 @@ export abstract class CommonTrainingInstanceEditService extends CommonTrainingIn
                 this.getAllSandboxDefinitions(sandboxDefinitionPagination),
             );
         }
-
         return this.loadingTracker.trackRequest(() =>
-            concat([
+            concat(
                 this.trainingInstanceApi.update(this.editedSnapshot).pipe(
                     tap(
                         () => {
@@ -258,8 +257,8 @@ export abstract class CommonTrainingInstanceEditService extends CommonTrainingIn
                         },
                     ),
                 ),
-                forkJoin(observables),
-            ]).pipe(map(() => void 0)),
+                forkJoin(observables)
+            ).pipe(map(() => void 0)),
         );
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@crczp/platform",
-    "version": "2.5.3",
+    "version": "2.5.4",
     "license": "MIT",
     "private": true,
     "dependencies": {


### PR DESCRIPTION
The `concat` method was used with array of observables instead of using varargs. This issue was not caught due to the obserable not being required to return actual type, as the result is unused. 

This cause the full frontend call to complete seemingly without errors, but the change was not persisted in the backend.