### PR TITLE
Null os_type support and internet node background fix

### DIFF
--- a/libs/api/sandbox-api/src/dto/topology/topology-dto.model.ts
+++ b/libs/api/sandbox-api/src/dto/topology/topology-dto.model.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 
 export class HostNodeDTO extends Z.class({
     name: z.string(),
-    os_type: z.string(),
+    os_type: z.string().nullable(),
     gui_access: z.boolean(),
     is_accessible: z.boolean(),
     ip: z.string().nullable(),

--- a/libs/api/sandbox-api/src/mappers/topology/topology-mapper.ts
+++ b/libs/api/sandbox-api/src/mappers/topology/topology-mapper.ts
@@ -7,11 +7,22 @@ import {
 } from '../../dto/topology/topology-dto.model';
 import {
     HostNode,
-    parseOsType,
+    OsType,
     RouterNode,
     Subnet,
     Topology,
 } from '@crczp/sandbox-model';
+
+export function parseOsType(input: string | undefined): OsType {
+    switch (input) {
+        case 'windows':
+            return 'windows';
+        case 'linux':
+            return 'linux';
+        default:
+            return 'other';
+    }
+}
 
 const hostMapper = MapperBuilder.createDTOtoModelMapper<HostNodeDTO, HostNode>({
     mappedProperties: ['name', 'ip', 'guiAccess', 'isAccessible'],


### PR DESCRIPTION
Added support for arbitrary os_type value, as some users may not have windows or linux specified (or even null value can occur).

Added awaiting for INTERNET node background rendering. The background depends on async loaded asset. Without the await, the asset won't be available until it is cached. This was causing the internet node to have blank background on first load.