### PR TITLE
Topology fixes

### DIFF
--- a/libs/api/sandbox-api/src/dto/topology/topology-dto.model.ts
+++ b/libs/api/sandbox-api/src/dto/topology/topology-dto.model.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 
 export class HostNodeDTO extends Z.class({
     name: z.string(),
-    os_type: z.string(),
+    os_type: z.string().nullable(),
     gui_access: z.boolean(),
     is_accessible: z.boolean(),
     ip: z.string().nullable(),

--- a/libs/api/sandbox-api/src/mappers/topology/topology-mapper.ts
+++ b/libs/api/sandbox-api/src/mappers/topology/topology-mapper.ts
@@ -7,11 +7,22 @@ import {
 } from '../../dto/topology/topology-dto.model';
 import {
     HostNode,
-    parseOsType,
+    OsType,
     RouterNode,
     Subnet,
     Topology,
 } from '@crczp/sandbox-model';
+
+export function parseOsType(input: string | undefined): OsType {
+    switch (input) {
+        case 'windows':
+            return 'windows';
+        case 'linux':
+            return 'linux';
+        default:
+            return 'other';
+    }
+}
 
 const hostMapper = MapperBuilder.createDTOtoModelMapper<HostNodeDTO, HostNode>({
     mappedProperties: ['name', 'ip', 'guiAccess', 'isAccessible'],

--- a/libs/components/src/topology-graph/topology-component/topology-graph/services/topology-svg-generator.service.ts
+++ b/libs/components/src/topology-graph/topology-component/topology-graph/services/topology-svg-generator.service.ts
@@ -18,16 +18,19 @@ export class TopologyNodeSvgService {
     private textMeasureContext?: CanvasRenderingContext2D;
     private readonly iconsService = inject(TopologyIconsService);
 
-    public get INTERNET_SVG(): string {
-        const internetIconUri = this.iconsService.getPreloadedIcon('INTERNET');
+    public generateInternetSvg(): Observable<string> {
+        return this.iconsService.isLoading$.pipe(
+            skipWhile((loading) => loading),
+            map(() => {
+                const internetIconUri = this.iconsService.getPreloadedIcon('INTERNET');
 
-        const radius = 128;
+                const radius = 128;
 
-        const svgSize = radius * 2;
-        const centerX = svgSize / 2;
-        const centerY = svgSize / 2;
+                const svgSize = radius * 2;
+                const centerX = svgSize / 2;
+                const centerY = svgSize / 2;
 
-        const svgContent = `
+                const svgContent = `
             <svg width="${svgSize}" height="${svgSize}" xmlns="http://www.w3.org/2000/svg">
                     <defs>
                        <radialGradient id="internet-border"
@@ -101,7 +104,9 @@ export class TopologyNodeSvgService {
             </g>
             </svg>`.trim();
 
-        return `data:image/svg+xml;base64,${btoa(svgContent)}`;
+                return `data:image/svg+xml;base64,${btoa(svgContent)}`;
+            }),
+        );
     }
 
     public generateNodeSvg(
@@ -133,7 +138,7 @@ export class TopologyNodeSvgService {
                                   ],
                           }
                         : null,
-                    deviceType !== 'INTERNET'
+                    deviceType !== 'INTERNET' && osType !== 'other'
                         ? {
                               uri: this.iconsService.getPreloadedIcon(
                                   osType.toUpperCase() as TopologyIcon,

--- a/libs/components/src/topology-graph/topology-component/topology-graph/topology-graph.ts
+++ b/libs/components/src/topology-graph/topology-component/topology-graph/topology-graph.ts
@@ -268,20 +268,29 @@ export class TopologyGraph implements AfterViewInit {
                 });
             }
             if (node.nodeType === 'INTERNET') {
-                return of({
-                    id: node.id,
-                    mass: this.getNodeMass('INTERNET'),
-                    shape: 'image',
-                    x: 0,
-                    y: 0,
-                    fixed: {
-                        x: true,
-                        y: true,
-                    },
-
-                    image: this.svgService.INTERNET_SVG,
-                    size: this.getNodeSize('INTERNET'),
-                });
+                return this.svgService.generateInternetSvg().pipe(
+                    map((svgDataUri) => ({
+                        id: node.id,
+                        mass: this.getNodeMass('INTERNET'),
+                        shape: 'image',
+                        x: 0,
+                        y: 0,
+                        fixed: {
+                            x: true,
+                            y: true,
+                        },
+                        image: svgDataUri,
+                        size: this.getNodeSize('INTERNET'),
+                    })),
+                    catchError((err) => {
+                        this.errorHandlerService.emitFrontendErrorNotification(
+                            'Could not create internet node SVG',
+                            'Topology graph',
+                        );
+                        console.error(err);
+                        return EMPTY;
+                    }),
+                );
             }
             return this.svgService
                 .generateNodeSvg(

--- a/libs/model/sandbox-model/src/topology-graph/topology.ts
+++ b/libs/model/sandbox-model/src/topology-graph/topology.ts
@@ -1,13 +1,9 @@
 import { Z } from 'zod-class';
 import { z } from 'zod';
 
-const osType = z.enum(['linux', 'windows']);
+const osType = z.enum(['linux', 'windows', 'other']);
 
 export type OsType = z.infer<typeof osType>;
-
-export function parseOsType(input: string | undefined): z.infer<typeof osType> {
-    return osType.parse(input);
-}
 
 export class HostNode extends Z.class({
     name: z.string(),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@crczp/platform",
-    "version": "2.5.4",
+    "version": "2.5.5",
     "license": "MIT",
     "private": true,
     "dependencies": {


### PR DESCRIPTION
Fix blank internet node background caused by not waiting for the image preload when generating the node svg.

Added support for arbitrary value in os_type field, as some users reported having null value returned by OpenStack.
  - Unrecognized values are mapped to 'other' type
  - Unrecognized values have no OS icon and only SSH connection