### PR TITLE
Sql visualizations

### DIFF
--- a/libs/agenda/training-agenda/definition-edit/components/levels/level/assessment/question/extended-matching-items/extended-matching-items-edit.component.html
+++ b/libs/agenda/training-agenda/definition-edit/components/levels/level/assessment/question/extended-matching-items/extended-matching-items-edit.component.html
@@ -1,9 +1,9 @@
-<form [formGroup]="extendedMatchingQuestionFormGroup.formGroup">
-    <div class="content">
-        <div class="form-container">
+<form [formGroup]="extendedMatchingQuestionFormGroup.formGroup" class="emi-edit">
+    <div class="emi-edit__content">
+        <div class="emi-edit__form-container">
             <!-- TITLE field-->
             <h3>Title</h3>
-            <div class='question-text'>
+            <div class="emi-edit__question-text">
                 <sentinel-markdown-editor
                     (contentChange)="title.setValue($event)"
                     [content]="title.value"
@@ -16,7 +16,7 @@
 
             <!--SCORE field -->
             @if (isTest) {
-                <div class="inline-input">
+                <div class="emi-edit__inline-input">
                     <mat-form-field appearance="outline" hintLabel="Number in range from 0
           to {{ maxQuestionScore }}">
                         <mat-label>Points</mat-label>
@@ -58,21 +58,15 @@
             }
         </div>
 
-        @if (isTest) {
-            <button [disabled]="!isCheckedAnyOption()"
-                    mat-button color="warn" (click)="clearAnswers()" class="clear-answers">Clear
-                Answers
-            </button>
-        }
+
         <!-- EMI -->
-        <div class="emi-answers">
+        <div class="emi-edit__answers">
             <table>
                 <!-- DELETE OPTION BUTTONS -->
-                <tr class="first-statement">
-                    <td></td>
+                <tr class="emi-edit__row emi-edit__row--first">
+                    <td class="emi-edit__cell"></td>
                     @for (option of options.controls; track option; let i = $index) {
-                        <td
-                            class="delete-col-buttons">
+                        <td class="emi-edit__cell">
                             <button matSuffix mat-icon-button aria-label="Delete
               option" color="warn" matTooltip="Delete option"
                                     (click)="deleteOption(i)">
@@ -82,31 +76,32 @@
                     }
                 </tr>
                 <!-- OPTION HEADER -->
-                <tr class="inner">
-                    <td></td>
+                <tr class="emi-edit__row">
+                    <td class="emi-edit__cell">
+                        @if (isTest) {
+                            <button [disabled]="!isCheckedAnyOption()"
+                                    mat-flat-button color="warn" (click)="clearAnswers()" class="emi-edit__clear-button">Clear
+                                Answers
+                            </button>
+                        }
+                    </td>
 
                     @for (option of options.controls; track trackByFn(i); let i = $index) {
-                        <td formArrayName="options" class="col-header">
+                        <td formArrayName="options" class="emi-edit__cell">
                             <!-- OPTION NAME -->
                             <div [formGroupName]="i">
-                                <mat-form-field class="option-field"
+                                <mat-form-field class="emi-edit__option-field"
                                                 (keydown.enter)="$event.preventDefault()">
                                     <mat-label>Option {{ i + 1 }}</mat-label>
                                     <input matInput placeholder="Option {{ i + 1 }}"
                                            [formControl]="$any(option.get('text'))" required>
-                                    @if (option.get('text').value) {
-                                        <button matSuffix mat-icon-button
-                                                aria-label="Clear" (click)="option.get('text').setValue('')">
-                                            <mat-icon>close</mat-icon>
-                                        </button>
-                                    }
                                 </mat-form-field>
                             </div>
                         </td>
                     }
 
                     <!-- ADD OPTION BUTTON -->
-                    <td class="last-option">
+                    <td class="emi-edit__cell emi-edit__cell--last">
                         @if (!columnLimitReached) {
                             <button matSuffix mat-icon-button aria-label="Add option"
                                     color="primary" matTooltip="Add option"
@@ -118,27 +113,22 @@
                 </tr>
                 <!-- STATEMENTS WITH RADIO BUTTONS -->
                 @for (statement of statements.controls; track trackByFn(i); let i = $index) {
-                    <tr formArrayName="statements" class="inner">
-                        <td [formGroupName]="i">
+                    <tr formArrayName="statements" class="emi-edit__row">
+                        <td class="emi-edit__cell" [formGroupName]="i">
                             <!-- STATEMENT NAME -->
-                            <mat-form-field class="statement-field"
+                            <mat-form-field
+                                class="emi-edit__statement-field"
                                             (keydown.enter)="$event.preventDefault()">
                                 <mat-label>Statement {{ i + 1 }}</mat-label>
                                 <input matInput placeholder="Statement {{ i + 1 }}"
                                        [formControl]="$any(statement.get('text'))"
                                        required>
-                                @if (statement.get('text').value) {
-                                    <button matSuffix mat-icon-button
-                                            aria-label="Clear" (click)="statement.get('text').setValue('')">
-                                        <mat-icon>close</mat-icon>
-                                    </button>
-                                }
                             </mat-form-field>
                         </td>
                         <!-- STATEMENT OPTIONS -->
                         <mat-radio-group>
                             @for (option of getOptions(); track option; let j = $index) {
-                                <td>
+                                <td class="emi-edit__cell">
                                     <mat-radio-button [disabled]="!isTest || !required"
                                                       [value]="{ x: i, y: j }"
                                                       [checked]="isOptionChecked(statement, j)"
@@ -147,7 +137,7 @@
                             }
                         </mat-radio-group>
                         <!-- DELETE STATEMENT BUTTON -->
-                        <td class="last-option">
+                        <td class="emi-edit__cell emi-edit__cell--last">
                             <button matSuffix mat-icon-button aria-label="Delete statement"
                                     color="warn" matTooltip="Delete statement"
                                     (click)="deleteStatement(i)">
@@ -157,8 +147,8 @@
                     </tr>
                 }
                 <!-- ADD STATEMENT BUTTON -->
-                <tr class="last-statement">
-                    <td>
+                <tr class="emi-edit__row emi-edit__row--last">
+                    <td class="emi-edit__cell emi-edit__cell--add-statement">
                         <button (click)="addStatement()" aria-label="Add new
               statement" color="primary" mat-icon-button matSuffix
                                 matTooltip="Add new statement">

--- a/libs/agenda/training-agenda/definition-edit/components/levels/level/assessment/question/extended-matching-items/extended-matching-items-edit.component.scss
+++ b/libs/agenda/training-agenda/definition-edit/components/levels/level/assessment/question/extended-matching-items/extended-matching-items-edit.component.scss
@@ -1,99 +1,95 @@
-.content {
+
+$_cell_width: 20rem;
+$_end_button_width: 4rem;
+
+.emi-edit__content {
     display: flex;
     flex-direction: column;
 }
 
-.inline-input {
-    display: flex;
-    flex-direction: row;
-    align-content: space-between;
-}
-
-.inline-input > * {
-    flex-grow: 1;
-    margin-right: 10px;
-}
-
-p.required-switch-note {
-    text-align: right;
-    color: #f44336;
-}
-
-.emi-answers {
-    width: 100%;
-    max-width: 100%;
-    overflow-x: auto;
-}
-
-tr {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    align-content: center;
-    border-bottom: 1px solid #ddd;
-}
-
-tr.first-statement {
-    border-top: 0;
-}
-
-tr.last-statement {
-    border-bottom: 0;
-}
-
-tr.inner:hover {
-    background-color: gainsboro;
-}
-
-tr mat-form-field {
-    text-align: center;
-    margin-top: 5px;
-    margin-bottom: -1.25em;
-    width: 120px;
-}
-
-td {
-    padding: 0;
-    width: 130px;
-    text-align: center;
-    align-items: center;
-    align-content: center;
-}
-
-.form-container {
+.emi-edit__form-container {
     display: flex;
     flex-direction: column;
     width: 90%;
     margin-bottom: 10px;
 }
 
-mat-form-field.option-field {
-    width: 120px;
-}
-
-mat-form-field.statement-field {
-    width: 120px;
-}
-
-.right-panel mat-form-field {
-    width: 100%;
-}
-
-mat-divider {
-    margin: 0 20px;
-}
-
-button.clear-answers {
-    width: 120px;
-    float: right;
-}
-
-@media screen and (max-width: 850px) {
-}
-
-.question-text {
+.emi-edit__question-text {
     display: flex;
     flex-direction: column;
     width: calc(100% - 10px);
     margin-bottom: 10px;
+}
+
+.emi-edit__inline-input {
+    display: flex;
+    flex-direction: row;
+    align-content: space-between;
+    border-radius: 0;
+
+    & > * {
+        flex-grow: 1;
+        margin-right: 10px;
+    }
+}
+
+.emi-edit__clear-button {
+    width: fit-content;
+}
+
+.emi-edit__answers {
+    width: 100%;
+    max-width: 100%;
+    overflow-x: auto;
+    overflow-y: hidden;
+}
+
+.emi-edit__row {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    align-content: center;
+    border-bottom: 1px solid #ddd;
+
+    &--first {
+        border-top: 0;
+        margin-right: $_end_button_width;
+    }
+
+    &--last {
+        border-bottom: 0;
+    }
+}
+
+.emi-edit__cell {
+    padding: 0;
+    min-width: $_cell_width;
+    width: 100%;
+    text-align: center;
+    align-items: center;
+    align-content: center;
+
+    &--last {
+        flex: 0 0 $_end_button_width;
+        min-width: $_end_button_width;
+    }
+
+
+    &--add-statement{
+        width: $_cell_width;
+    }
+}
+
+.emi-edit__option-field {
+    text-align: center;
+    margin-top: 5px;
+    margin-bottom: -1.25em;
+    width: calc(100% - 0.25rem);
+}
+
+.emi-edit__statement-field {
+    text-align: center;
+    margin-top: 5px;
+    margin-bottom: -1.25em;
+    width: calc(100% - 0.25rem);
 }

--- a/libs/agenda/training-agenda/definition-edit/components/levels/level/assessment/question/extended-matching-items/extended-matching-items-edit.component.ts
+++ b/libs/agenda/training-agenda/definition-edit/components/levels/level/assessment/question/extended-matching-items/extended-matching-items-edit.component.ts
@@ -7,7 +7,7 @@ import {
     Input,
     OnChanges,
     Output,
-    SimpleChanges,
+    SimpleChanges
 } from '@angular/core';
 import {
     AbstractControl,
@@ -16,16 +16,16 @@ import {
     UntypedFormControl,
     UntypedFormGroup
 } from '@angular/forms';
-import {SentinelValidators} from '@sentinel/common';
-import {ExtendedMatchingItems, Question} from '@crczp/training-model';
-import {ExtendedMatchingItemsFormGroup} from './extended-matching-items-form-group';
-import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
-import {MatError, MatFormField, MatInput, MatLabel, MatSuffix} from "@angular/material/input";
-import {MatButton, MatIconButton} from "@angular/material/button";
-import {MatRadioButton, MatRadioGroup} from "@angular/material/radio";
-import {MatTooltip} from "@angular/material/tooltip";
-import {MatIcon} from "@angular/material/icon";
-import {SentinelMarkdownEditorComponent} from "@sentinel/components/markdown-editor";
+import { SentinelValidators } from '@sentinel/common';
+import { ExtendedMatchingItems, Question } from '@crczp/training-model';
+import { ExtendedMatchingItemsFormGroup } from './extended-matching-items-form-group';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { MatError, MatFormField, MatInput, MatLabel, MatSuffix } from '@angular/material/input';
+import { MatButton, MatIconButton } from '@angular/material/button';
+import { MatRadioButton, MatRadioGroup } from '@angular/material/radio';
+import { MatTooltip } from '@angular/material/tooltip';
+import { MatIcon } from '@angular/material/icon';
+import { SentinelMarkdownEditorComponent } from '@sentinel/components/markdown-editor';
 
 /**
  * Component for editing a question of type Extended Matching Items

--- a/libs/api/api-common/src/crczp-http.service.ts
+++ b/libs/api/api-common/src/crczp-http.service.ts
@@ -365,14 +365,22 @@ class BodylessRequestBuilder<TRecv, TOut = TRecv> extends BaseRequestBuilder<
      * @param key Optional cache key override.
      */
     withCache(ttl: CacheTTL, key: string | null = null) {
+        const cacheContext = withCache({
+            storage: 'localStorage',
+            ttl: mapCacheTTLToMs(ttl),
+            version: this.version,
+            ...(key ? { key } : {}),
+        });
+        const existingContext = this.options.context;
+        if (existingContext) {
+            const skippedErrors = existingContext.get(SKIPPED_ERROR_CODES);
+            if (skippedErrors.length > 0) {
+                cacheContext.set(SKIPPED_ERROR_CODES, skippedErrors);
+            }
+        }
         this.options = {
             ...this.options,
-            context: withCache({
-                storage: 'localStorage',
-                ttl: mapCacheTTLToMs(ttl),
-                version: this.version,
-                ...(key ? { key } : {}),
-            }),
+            context: cacheContext,
         };
         return this;
     }

--- a/libs/api/api-common/src/index.ts
+++ b/libs/api/api-common/src/index.ts
@@ -11,6 +11,8 @@ export * from './validation/json-error-converter';
 export * from './validation/presence-validator';
 export * from './pagination/offset-paginated-resource';
 export * from './pagination/crczp-offset-elements-paginated-service-';
+export * from './opensearch/crczp-opensearch-api.service';
+export * from './opensearch/opensearch-response-dto';
 
 
 export type {

--- a/libs/api/api-common/src/opensearch/crczp-opensearch-api.service.ts
+++ b/libs/api/api-common/src/opensearch/crczp-opensearch-api.service.ts
@@ -1,0 +1,24 @@
+import { inject, Injectable } from '@angular/core';
+import { CRCZPHttpService } from '../crczp-http.service';
+import { PortalConfig } from '@crczp/utils';
+import { Observable } from 'rxjs';
+import { OpensearchResponseDto } from './opensearch-response-dto';
+
+@Injectable({
+    providedIn: 'root',
+})
+export class CrczpOpensearchApiService {
+    private readonly httpService = inject(CRCZPHttpService);
+    private readonly endpoint =
+        inject(PortalConfig).basePaths.linearTraining + '/opensearch/sql';
+
+    public executeQuery(query: string): Observable<OpensearchResponseDto> {
+        return this.httpService
+            .get<OpensearchResponseDto>(
+                this.endpoint,
+                'Send SQL query to OpenSearch',
+            )
+            .withParams({ query })
+            .execute();
+    }
+}

--- a/libs/api/api-common/src/opensearch/opensearch-response-dto.ts
+++ b/libs/api/api-common/src/opensearch/opensearch-response-dto.ts
@@ -1,0 +1,13 @@
+
+
+
+export class OpensearchResponseDto {
+
+    public hasMore: boolean;
+
+    public pageSize: number;
+
+    public data: object;
+
+
+}

--- a/libs/api/opensearch-query-builder/README.md
+++ b/libs/api/opensearch-query-builder/README.md
@@ -1,0 +1,215 @@
+# @crczp/opensearch-query-builder
+
+A strongly typed SQL query builder for OpenSearch, designed for querying CyberRangeCZ Platform training event indices.
+
+Produces valid OpenSearch SQL strings with compile-time type safety — field names and value types are enforced against the training event schema.
+
+## Installation
+
+The library is part of the platform monorepo. Import from the package name:
+
+```typescript
+import { QueryBuilder, field, eq, count, EventType } from '@crczp/opensearch-query-builder';
+```
+
+## Quick start
+
+```typescript
+const sql = new QueryBuilder('crczp.events.trainings.*')
+    .select(field('training_run_id'), field('type'), as(count('*'), 'cnt'))
+    .where(and(
+        eq('training_instance_id', 5),
+        inList('type', [EventType.LevelStarted, EventType.LevelCompleted]),
+    ))
+    .groupBy(field('training_run_id'), field('type'))
+    .orderBy(count('*'), 'DESC')
+    .limit(100)
+    .toSQL();
+```
+
+Output:
+
+```sql
+SELECT training_run_id, type, COUNT(*) AS cnt
+FROM crczp.events.trainings.*
+WHERE (training_instance_id = 5 AND type IN ('cz.cyberrange.platform.events.trainings.LevelStarted', 'cz.cyberrange.platform.events.trainings.LevelCompleted'))
+GROUP BY training_run_id, type
+ORDER BY COUNT(*) DESC
+LIMIT 100
+```
+
+## Index targeting
+
+```typescript
+// All runs across all instances
+new QueryBuilder('crczp.events.trainings.*')
+
+// Single specific run
+new QueryBuilder('crczp.events.trainings.pool=1.sandbox=abc.definition=2.instance=3.run=4')
+
+// With alias (required for JOINs)
+new QueryBuilder('crczp.events.trainings.*', 'e')
+```
+
+## Type safety
+
+Field names and their value types are enforced at compile time via `FieldTypeMap`. Passing the wrong type for a field is a compile error:
+
+```typescript
+eq('timestamp', 'bad')  // TS error — timestamp is number
+eq('timestamp', 1234)   // ok
+
+like('training_run_id', '%foo%')  // TS error — training_run_id is not a string field
+like('level_title', '%intro%')    // ok
+```
+
+## Event types
+
+Use the `EventType` constant to avoid hardcoding event class names:
+
+```typescript
+eq('type', EventType.LevelCompleted)
+inList('type', [EventType.HintTaken, EventType.SolutionDisplayed])
+```
+
+## API reference
+
+### QueryBuilder
+
+| Method | Description |
+|--------|-------------|
+| `select(...elements)` | Replace the SELECT list |
+| `addSelect(...elements)` | Append to the SELECT list (removes a leading `*`) |
+| `selectAll()` | Reset SELECT to `*` |
+| `distinct(on?)` | Add DISTINCT |
+| `where(predicate)` | Set the WHERE clause |
+| `andWhere(predicate)` | AND a condition onto the existing WHERE, flattening into a single AND node |
+| `orWhere(predicate)` | OR a condition onto the existing WHERE, flattening into a single OR node |
+| `groupBy(...exprs)` | Set GROUP BY |
+| `addGroupBy(...exprs)` | Append to GROUP BY |
+| `having(predicate)` | Set HAVING |
+| `andHaving(predicate)` | AND a condition onto HAVING |
+| `orderBy(expr, dir?, nulls?)` | Append an ORDER BY element |
+| `limit(n)` | Set LIMIT |
+| `offset(n)` | Set OFFSET (emitted as `LIMIT offset, size`) |
+| `join(index, alias, on)` | INNER JOIN |
+| `leftJoin(index, alias, on)` | LEFT JOIN |
+| `crossJoin(index, alias)` | CROSS JOIN (no ON clause) |
+| `clone()` | Independent copy of the builder |
+| `toSQL()` | Serialize to a SQL string |
+| `getState()` | Expose the underlying AST state |
+
+### Predicates
+
+```typescript
+// Comparison
+eq('training_run_id', 42)
+neq('level_type', 'ASSESSMENT')
+gt('actual_score_in_level', 80)
+gte('level', 1)
+lt('timestamp', 1800000000000)
+lte('max_score', 100)
+
+// Range / set
+between('timestamp', 1700000000000, 1800000000000)
+inList('type', [EventType.LevelStarted, EventType.LevelCompleted])
+notIn('level_order', [0, 9])
+
+// String pattern
+like('level_title', '%network%')
+notLike('type', '%Assessment%')
+
+// Null checks
+isNull('hint_title')
+isNotNull('end_time')
+
+// Full-text / relevance
+matchQuery('level_title', 'firewall', { analyzer: 'standard', boost: 1.5 })
+multiMatch(['type', 'level_title'], 'security', { operator: 'AND' })
+wildcardQuery('type', 'cz.cyberrange.*', 2)
+score(matchQuery('level_title', 'firewall'), 1.2)
+
+// Logical
+and(eq('training_run_id', 5), gt('level', 0))
+or(eq('type', EventType.HintTaken), eq('type', EventType.SolutionDisplayed))
+not(eq('level_type', 'ASSESSMENT'))
+```
+
+### Expressions
+
+```typescript
+// Field reference and literal
+field('training_run_id')
+lit(42)
+lit('hello')
+lit(null)
+
+// Alias
+as(count('*'), 'cnt')
+as(avg(field('actual_score_in_level')), 'avg_score')
+
+// Arithmetic
+add(field('actual_score_in_level'), lit(10))
+sub(field('end_time'), field('start_time'))
+mul(div(field('actual_score_in_level'), field('max_score')), lit(100))
+
+// Aggregates
+count()                                   // COUNT(*)
+count(field('user_ref_id'), true)         // COUNT(DISTINCT user_ref_id)
+sum(field('actual_score_in_level'))
+avg(field('actual_score_in_level'))
+min(field('timestamp'))
+max(field('total_assessment_level_score'))
+
+// Functions
+fn('DATE_FORMAT', field('timestamp'), lit('%Y-%m'))
+fn('IFNULL', field('hint_title'), lit('(no title)'))
+fn('TIMESTAMPDIFF', lit('SECOND'), field('start_time'), field('end_time'))
+
+// Shortcut functions
+dateFormat(field('timestamp'), lit('%Y-%m-%d'))
+round(avg(field('actual_score_in_level')), lit(2))
+cast(field('timestamp'), 'DATETIME')
+```
+
+## Examples
+
+**Score summary per run with a minimum threshold:**
+
+```typescript
+new QueryBuilder('crczp.events.trainings.*')
+    .select(
+        field('training_run_id'),
+        as(sum(field('actual_score_in_level')), 'total_score'),
+        as(round(avg(field('actual_score_in_level')), lit(2)), 'avg_score'),
+        as(count('*'), 'levels_completed'),
+    )
+    .where(and(
+        eq('type', EventType.LevelCompleted),
+        eq('training_instance_id', 12),
+    ))
+    .groupBy(field('training_run_id'))
+    .having(gt('total_score' as any, 200))
+    .orderBy(sum(field('actual_score_in_level')), 'DESC')
+    .limit(20)
+    .toSQL()
+```
+
+**Building query variants from a shared base using `clone()`:**
+
+```typescript
+const base = new QueryBuilder('crczp.events.trainings.*')
+    .select(field('user_ref_id'), field('level'), field('actual_score_in_level'))
+    .where(and(
+        eq('training_instance_id', 7),
+        eq('type', EventType.LevelCompleted),
+    ));
+
+const topScorers = base.clone()
+    .orderBy(field('actual_score_in_level'), 'DESC')
+    .limit(10);
+
+const lowScorers = base.clone()
+    .andWhere(lt('actual_score_in_level', 30))
+    .orderBy(field('actual_score_in_level'), 'ASC');
+```

--- a/libs/api/opensearch-query-builder/eslint.config.mjs
+++ b/libs/api/opensearch-query-builder/eslint.config.mjs
@@ -1,0 +1,50 @@
+import nx from '@nx/eslint-plugin';
+import baseConfig from '../../../eslint.config.mjs';
+
+export default [
+    ...baseConfig,
+    {
+        files: ['**/*.json'],
+        rules: {
+            '@nx/dependency-checks': [
+                'error',
+                {
+                    ignoredFiles: [
+                        '{projectRoot}/eslint.config.{js,cjs,mjs,ts,cts,mts}',
+                    ],
+                },
+            ],
+        },
+        languageOptions: {
+            parser: await import('jsonc-eslint-parser'),
+        },
+    },
+    ...nx.configs['flat/angular'],
+    ...nx.configs['flat/angular-template'],
+    {
+        files: ['**/*.ts'],
+        rules: {
+            '@angular-eslint/directive-selector': [
+                'error',
+                {
+                    type: 'attribute',
+                    prefix: 'lib',
+                    style: 'camelCase',
+                },
+            ],
+            '@angular-eslint/component-selector': [
+                'error',
+                {
+                    type: 'element',
+                    prefix: 'lib',
+                    style: 'kebab-case',
+                },
+            ],
+        },
+    },
+    {
+        files: ['**/*.html'],
+        // Override or add rules here
+        rules: {},
+    },
+];

--- a/libs/api/opensearch-query-builder/package.json
+++ b/libs/api/opensearch-query-builder/package.json
@@ -1,0 +1,9 @@
+{
+    "name": "@crczp/opensearch-query-builder",
+    "version": "1.0.0",
+    "peerDependencies": {
+        "@angular/common": "^20.3.0",
+        "@angular/core": "^20.3.0"
+    },
+    "sideEffects": false
+}

--- a/libs/api/opensearch-query-builder/project.json
+++ b/libs/api/opensearch-query-builder/project.json
@@ -1,0 +1,38 @@
+{
+    "name": "opensearch-query-builder",
+    "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+    "sourceRoot": "libs/api/opensearch-query-builder/src",
+    "prefix": "crczp",
+    "projectType": "library",
+    "tags": [],
+    "targets": {
+        "build": {
+            "executor": "@nx/js:tsc",
+            "outputs": ["{workspaceRoot}/dist/{projectRoot}"],
+            "options": {
+                "main": "libs/api/opensearch-query-builder/src/index.ts",
+                "outputPath": "dist/libs/api/opensearch-query-builder",
+                "tsConfig": "libs/api/opensearch-query-builder/tsconfig.lib.json"
+            },
+            "configurations": {
+                "production": {
+                    "tsConfig": "libs/api/opensearch-query-builder/tsconfig.lib.prod.json"
+                },
+                "development": {
+                    "tsConfig": "libs/api/opensearch-query-builder/tsconfig.lib.json"
+                }
+            },
+            "defaultConfiguration": "production"
+        },
+        "test": {
+            "executor": "@nx/vite:test",
+            "outputs": ["{options.reportsDirectory}"],
+            "options": {
+                "reportsDirectory": "../../../coverage/libs/api/opensearch-query-builder"
+            }
+        },
+        "lint": {
+            "executor": "@nx/eslint:lint"
+        }
+    }
+}

--- a/libs/api/opensearch-query-builder/src/index.ts
+++ b/libs/api/opensearch-query-builder/src/index.ts
@@ -100,4 +100,6 @@ export {
 
 export { QueryBuilder } from './lib/query-builder';
 
+export { IndexSelectorBuilder, PartialIndexSelectorBuilder } from './lib/index-selector-builder';
+
 export { toSQL } from './lib/sql';

--- a/libs/api/opensearch-query-builder/src/index.ts
+++ b/libs/api/opensearch-query-builder/src/index.ts
@@ -1,0 +1,103 @@
+/**
+ * Public API for the OpenSearch SQL query builder.
+ *
+ * Consumers only need to import from this barrel:
+ *
+ *   import { QueryBuilder, eq, field, count, EventType } from './opensearch-sql';
+ */
+
+// ─── Schema — values ───
+export { EventType } from './lib/schema';
+
+// ─── Schema — types ───
+export type {
+    EventTypeName,
+    FieldName,
+    FieldTypeMap,
+    FieldValue,
+    LevelType,
+    NumericFieldName,
+    PrimitiveFieldName,
+    StringFieldName,
+    TrainingIndex,
+} from './lib/schema';
+
+// ─── AST node types (for advanced / custom use) ───
+export type {
+    AggregateFunction,
+    AnyExpr,
+    ComparisonOp,
+    JoinClause,
+    JoinType,
+    MatchQueryOptions,
+    MultiMatchOptions,
+    OrderByElement,
+    Predicate,
+    QueryState,
+    SelectElement,
+    SupportedScalarFunction,
+    CastTargetType,
+} from './lib/ast';
+
+// ─── Predicate builders ───
+export {
+    and,
+    or,
+    not,
+    eq,
+    neq,
+    gt,
+    gte,
+    lt,
+    lte,
+    between,
+    inList,
+    notIn,
+    like,
+    notLike,
+    isNull,
+    isNotNull,
+    matchQuery,
+    multiMatch,
+    wildcardQuery,
+    score,
+} from './lib/predicates';
+
+// ─── Expression builders ───
+export {
+    field,
+    lit,
+    as,
+    add,
+    sub,
+    mul,
+    div,
+    cast,
+    agg,
+    count,
+    sum,
+    avg,
+    min,
+    max,
+    fn,
+    abs,
+    ceil,
+    floor,
+    round,
+    upper,
+    lower,
+    trim,
+    length,
+    year,
+    month,
+    day,
+    hour,
+    minute,
+    second,
+    now,
+    dateFormat,
+} from './lib/expressions';
+
+export { QueryBuilder } from './lib/query-builder';
+
+export { toSQL } from './lib/sql';

--- a/libs/api/opensearch-query-builder/src/lib/ast.ts
+++ b/libs/api/opensearch-query-builder/src/lib/ast.ts
@@ -17,6 +17,7 @@ import type {
     FieldValue,
     PrimitiveFieldName,
     StringFieldName,
+    TrainingIndex,
 } from './schema';
 
 // Predicates
@@ -252,7 +253,7 @@ export type JoinClause = {
 };
 
 export type QueryState = {
-    index:    string;  // TrainingIndex or any raw string for join targets
+    index:    TrainingIndex;
     alias?:   string;
     distinct: boolean;
     select:   SelectElement[];

--- a/libs/api/opensearch-query-builder/src/lib/ast.ts
+++ b/libs/api/opensearch-query-builder/src/lib/ast.ts
@@ -1,0 +1,266 @@
+/**
+ * AST node types for the OpenSearch SQL query builder.
+ *
+ * Two root hierarchies:
+ *   Predicate — used in WHERE / HAVING (boolean-valued)
+ *   AnyExpr   — used in SELECT / GROUP BY / ORDER BY / function args (scalar-valued)
+ *
+ * Generic parameters (e.g. `F extends FieldName`) are narrowed when building
+ * nodes via the helper functions in predicates.ts / expressions.ts so the
+ * compiler enforces value types per field. At the `Predicate`/`AnyExpr` union
+ * level the parameter defaults to the full union, which is correct for storage
+ * and serialization.
+ */
+
+import type {
+    FieldName,
+    FieldValue,
+    PrimitiveFieldName,
+    StringFieldName,
+} from './schema';
+
+// Predicates
+
+export type ComparisonOp = '=' | '<>' | '>' | '<' | '>=' | '<=';
+
+export type ComparisonPredicate<F extends PrimitiveFieldName = PrimitiveFieldName> = {
+    kind: 'comparison';
+    op:    ComparisonOp;
+    field: F;
+    value: FieldValue<F>;
+};
+
+export type BetweenPredicate<F extends PrimitiveFieldName = PrimitiveFieldName> = {
+    kind:  'between';
+    field: F;
+    from:  FieldValue<F>;
+    to:    FieldValue<F>;
+};
+
+export type InPredicate<F extends PrimitiveFieldName = PrimitiveFieldName> = {
+    kind:   'in';
+    field:  F;
+    values: FieldValue<F>[];
+    negate?: boolean; // true = NOT IN
+};
+
+/** SQL LIKE pattern — `%` matches any sequence, `_` matches any single char. */
+export type LikePredicate<F extends StringFieldName = StringFieldName> = {
+    kind:    'like';
+    field:   F;
+    pattern: string;
+    negate?: boolean; // true = NOT LIKE
+};
+
+export type NullPredicate<F extends FieldName = FieldName> = {
+    kind:   'null';
+    field:  F;
+    negate: boolean; // false = IS NULL, true = IS NOT NULL
+};
+
+// ─── Full-text / relevance predicates ───
+
+export type MatchQueryOptions = {
+    analyzer?: string;
+    boost?:    number;
+};
+
+export type MatchQueryPredicate<F extends StringFieldName = StringFieldName> = {
+    kind:     'match_query';
+    field:    F;
+    query:    string;
+    options?: MatchQueryOptions;
+};
+
+export type MultiMatchOptions = {
+    analyzer?:    string;
+    boost?:       number;
+    slop?:        number;
+    type?:        string;
+    tie_breaker?: number;
+    operator?:    'AND' | 'OR';
+};
+
+export type MultiMatchPredicate = {
+    kind:     'multi_match';
+    fields:   StringFieldName[];
+    query:    string;
+    options?: MultiMatchOptions;
+};
+
+export type WildcardQueryPredicate<F extends StringFieldName = StringFieldName> = {
+    kind:   'wildcard_query';
+    field:  F;
+    query:  string; // supports * and ? wildcards
+    boost?: number;
+};
+
+/**
+ * SCORE(MATCH_QUERY(field, 'query'), boost) — used in WHERE to filter by
+ * relevance score. See opensearch-functions doc.
+ */
+export type ScorePredicate = {
+    kind:      'score';
+    matchExpr: MatchQueryPredicate;
+    boost?:    number;
+};
+
+// ─── Logical connectives ───
+
+/** n-ary AND — serialised as (p1 AND p2 AND …). */
+export type AndPredicate = {
+    kind:     'and';
+    operands: Predicate[];
+};
+
+/** n-ary OR — serialised as (p1 OR p2 OR …). */
+export type OrPredicate = {
+    kind:     'or';
+    operands: Predicate[];
+};
+
+export type NotPredicate = {
+    kind: 'not';
+    expr: Predicate;
+};
+
+export type Predicate =
+    | ComparisonPredicate
+    | BetweenPredicate
+    | InPredicate
+    | LikePredicate
+    | NullPredicate
+    | MatchQueryPredicate
+    | MultiMatchPredicate
+    | WildcardQueryPredicate
+    | ScorePredicate
+    | AndPredicate
+    | OrPredicate
+    | NotPredicate;
+
+// Expressions
+
+export type FieldRef<F extends FieldName = FieldName> = {
+    kind: 'field';
+    name: F;
+};
+
+export type Literal = {
+    kind:  'literal';
+    value: string | number | boolean | null;
+};
+
+export type ArithmeticOp = '+' | '-' | '*' | '/';
+
+export type ArithmeticExpr = {
+    kind:  'arithmetic';
+    op:    ArithmeticOp;
+    left:  AnyExpr;
+    right: AnyExpr;
+};
+
+export type AggregateFunction = 'COUNT' | 'AVG' | 'SUM' | 'MIN' | 'MAX';
+
+export type AggregateExpr = {
+    kind:      'aggregate';
+    fn:        AggregateFunction;
+    arg:       AnyExpr | '*'; // COUNT(*) uses '*'
+    distinct?: boolean;
+};
+
+export type SupportedScalarFunction =
+    // Math
+    | 'ABS' | 'CEIL' | 'FLOOR' | 'ROUND' | 'SQRT' | 'POW' | 'MOD'
+    | 'LOG' | 'LOG2' | 'LOG10' | 'EXP'
+    // String
+    | 'UPPER' | 'LOWER' | 'TRIM' | 'LTRIM' | 'RTRIM' | 'LENGTH'
+    | 'SUBSTRING' | 'REPLACE' | 'CONCAT' | 'LEFT' | 'RIGHT'
+    | 'LOCATE' | 'REVERSE'
+    // Date / time
+    | 'NOW' | 'CURDATE' | 'DATE' | 'TIME' | 'YEAR' | 'MONTH' | 'DAY'
+    | 'HOUR' | 'MINUTE' | 'SECOND' | 'DAYOFWEEK' | 'DAYOFMONTH'
+    | 'DAYOFYEAR' | 'DATE_FORMAT' | 'DATE_ADD' | 'DATE_SUB'
+    | 'DATEDIFF' | 'TIMESTAMPDIFF'
+    // Conditional
+    | 'IF' | 'IFNULL' | 'NULLIF' | 'ISNULL';
+
+export type FunctionExpr = {
+    kind: 'function';
+    name: SupportedScalarFunction;
+    args: AnyExpr[];
+};
+
+/**
+ * CAST(expr AS type) — separate from FunctionExpr because its syntax is
+ * `CAST(expr AS TYPE_KEYWORD)` rather than `fn(arg, arg)`.
+ */
+export type CastTargetType =
+    | 'INT' | 'LONG' | 'DOUBLE' | 'FLOAT' | 'STRING'
+    | 'DATE' | 'TIME' | 'DATETIME' | 'BOOLEAN';
+
+export type CastExpr = {
+    kind:       'cast';
+    expr:       AnyExpr;
+    targetType: CastTargetType;
+};
+
+export type AnyExpr =
+    | FieldRef
+    | Literal
+    | ArithmeticExpr
+    | FunctionExpr
+    | AggregateExpr
+    | CastExpr;
+
+/** An expression given a SQL alias: `expr AS alias`. */
+export type Aliased<E extends AnyExpr = AnyExpr> = {
+    kind:  'aliased';
+    expr:  E;
+    alias: string;
+};
+
+/** One element of a SELECT list. */
+export type SelectElement = AnyExpr | Aliased | '*';
+
+// Query structure
+
+export type OrderByElement = {
+    expr:      AnyExpr;
+    direction: 'ASC' | 'DESC';
+    /**
+     * OpenSearch's default is NULLS LAST.
+     * 'FIRST' emits `IS NOT NULL` before ASC/DESC (reverses the default).
+     * 'LAST'  emits `IS NULL`     before ASC/DESC (explicit default).
+     * Omitting produces no null-ordering clause.
+     */
+    nulls?: 'FIRST' | 'LAST';
+};
+
+export type JoinType = 'INNER' | 'LEFT' | 'CROSS';
+
+/**
+ * Join clause — intentionally untyped for field references.
+ * OpenSearch SQL only supports two-index joins; additional JOINs will produce
+ * invalid SQL (the builder does not enforce this constraint).
+ */
+export type JoinClause = {
+    type:   JoinType;
+    index:  string;
+    alias:  string;
+    /** CROSS joins have no ON condition. */
+    on?: { left: string; right: string }[];
+};
+
+export type QueryState = {
+    index:    string;  // TrainingIndex or any raw string for join targets
+    alias?:   string;
+    distinct: boolean;
+    select:   SelectElement[];
+    joins:    JoinClause[];
+    where:    Predicate | null;
+    groupBy:  AnyExpr[];
+    having:   Predicate | null;
+    orderBy:  OrderByElement[];
+    limit:    number | null;
+    offset:   number | null;
+};

--- a/libs/api/opensearch-query-builder/src/lib/expressions.ts
+++ b/libs/api/opensearch-query-builder/src/lib/expressions.ts
@@ -1,0 +1,115 @@
+/**
+ * Expression builder functions.
+ *
+ * Example:
+ *   select(
+ *     field('type'),
+ *     as(count('*'), 'cnt'),
+ *     as(fn('DATE_FORMAT', field('timestamp'), lit('%Y-%m')), 'month'),
+ *   )
+ */
+
+import type {
+    AggregateExpr,
+    AggregateFunction,
+    Aliased,
+    AnyExpr,
+    ArithmeticExpr,
+    CastExpr,
+    CastTargetType,
+    FieldRef,
+    FunctionExpr,
+    Literal,
+    SupportedScalarFunction
+} from './ast';
+import type { FieldName } from './schema';
+
+// ─── Primitives ───
+
+export function field<F extends FieldName>(name: F): FieldRef<F> {
+    return { kind: 'field', name };
+}
+
+export function lit(value: string | number | boolean | null): Literal {
+    return { kind: 'literal', value };
+}
+
+// ─── Alias ───
+
+export function as<E extends AnyExpr>(expr: E, alias: string): Aliased<E> {
+    return { kind: 'aliased', expr, alias };
+}
+
+// ─── Arithmetic ───
+
+export function add(left: AnyExpr, right: AnyExpr): ArithmeticExpr {
+    return { kind: 'arithmetic', op: '+', left, right };
+}
+
+export function sub(left: AnyExpr, right: AnyExpr): ArithmeticExpr {
+    return { kind: 'arithmetic', op: '-', left, right };
+}
+
+export function mul(left: AnyExpr, right: AnyExpr): ArithmeticExpr {
+    return { kind: 'arithmetic', op: '*', left, right };
+}
+
+export function div(left: AnyExpr, right: AnyExpr): ArithmeticExpr {
+    return { kind: 'arithmetic', op: '/', left, right };
+}
+
+// ─── CAST ───
+
+/** CAST(expr AS TYPE) — uses keyword syntax, not a regular function call. */
+export function cast(expr: AnyExpr, targetType: CastTargetType): CastExpr {
+    return { kind: 'cast', expr, targetType };
+}
+
+// ─── Aggregate functions ───
+
+export function agg(
+    fn:       AggregateFunction,
+    arg:      AnyExpr | '*',
+    distinct?: boolean,
+): AggregateExpr {
+    return { kind: 'aggregate', fn, arg, distinct };
+}
+
+export const count = (arg: AnyExpr | '*' = '*', distinct?: boolean): AggregateExpr => agg('COUNT', arg, distinct);
+export const sum   = (arg: AnyExpr): AggregateExpr => agg('SUM', arg);
+export const avg   = (arg: AnyExpr): AggregateExpr => agg('AVG', arg);
+export const min   = (arg: AnyExpr): AggregateExpr => agg('MIN', arg);
+export const max   = (arg: AnyExpr): AggregateExpr => agg('MAX', arg);
+
+// ─── Scalar functions (generic) ───
+
+export function fn(name: SupportedScalarFunction, ...args: AnyExpr[]): FunctionExpr {
+    return { kind: 'function', name, args };
+}
+
+// ─── Scalar function shortcuts ───
+// Only the functions most likely to appear in training-event queries are listed
+// as shortcuts. Use fn(...) directly for anything else.
+
+// Math
+export const abs   = (x: AnyExpr): FunctionExpr => fn('ABS', x);
+export const ceil  = (x: AnyExpr): FunctionExpr => fn('CEIL', x);
+export const floor = (x: AnyExpr): FunctionExpr => fn('FLOOR', x);
+export const round = (x: AnyExpr, decimals?: AnyExpr): FunctionExpr =>
+    decimals ? fn('ROUND', x, decimals) : fn('ROUND', x);
+
+// String
+export const upper  = (x: AnyExpr): FunctionExpr => fn('UPPER', x);
+export const lower  = (x: AnyExpr): FunctionExpr => fn('LOWER', x);
+export const trim   = (x: AnyExpr): FunctionExpr => fn('TRIM', x);
+export const length = (x: AnyExpr): FunctionExpr => fn('LENGTH', x);
+
+// Date / time — particularly useful for bucketing events by time period
+export const year       = (x: AnyExpr): FunctionExpr => fn('YEAR', x);
+export const month      = (x: AnyExpr): FunctionExpr => fn('MONTH', x);
+export const day        = (x: AnyExpr): FunctionExpr => fn('DAY', x);
+export const hour       = (x: AnyExpr): FunctionExpr => fn('HOUR', x);
+export const minute     = (x: AnyExpr): FunctionExpr => fn('MINUTE', x);
+export const second     = (x: AnyExpr): FunctionExpr => fn('SECOND', x);
+export const now        = (): FunctionExpr => fn('NOW');
+export const dateFormat = (date: AnyExpr, format: AnyExpr): FunctionExpr => fn('DATE_FORMAT', date, format);

--- a/libs/api/opensearch-query-builder/src/lib/predicates.ts
+++ b/libs/api/opensearch-query-builder/src/lib/predicates.ts
@@ -1,0 +1,149 @@
+/**
+ * Predicate builder functions.
+ *
+ * Every function is generic over the field name so the compiler enforces that
+ * the supplied value matches the field's declared type in FieldTypeMap.
+ *
+ * Example:
+ *   eq('timestamp', 'bad')  // TS error — timestamp is number
+ *   eq('timestamp', 1234)   // ok
+ */
+
+import type {
+    BetweenPredicate,
+    ComparisonOp,
+    ComparisonPredicate,
+    InPredicate,
+    LikePredicate,
+    MatchQueryOptions,
+    MatchQueryPredicate,
+    MultiMatchOptions,
+    MultiMatchPredicate,
+    NotPredicate,
+    NullPredicate,
+    Predicate,
+    ScorePredicate,
+    WildcardQueryPredicate,
+} from './ast';
+import type { FieldName, FieldValue, PrimitiveFieldName, StringFieldName } from './schema';
+
+// ─── Comparison ───
+
+function comparison<F extends PrimitiveFieldName>(
+    op: ComparisonOp,
+    field: F,
+    value: FieldValue<F>,
+): ComparisonPredicate<F> {
+    return { kind: 'comparison', op, field, value };
+}
+
+export const eq  = <F extends PrimitiveFieldName>(field: F, value: FieldValue<F>): ComparisonPredicate<F> => comparison('=',  field, value);
+export const neq = <F extends PrimitiveFieldName>(field: F, value: FieldValue<F>): ComparisonPredicate<F> => comparison('<>', field, value);
+export const gt  = <F extends PrimitiveFieldName>(field: F, value: FieldValue<F>): ComparisonPredicate<F> => comparison('>',  field, value);
+export const gte = <F extends PrimitiveFieldName>(field: F, value: FieldValue<F>): ComparisonPredicate<F> => comparison('>=', field, value);
+export const lt  = <F extends PrimitiveFieldName>(field: F, value: FieldValue<F>): ComparisonPredicate<F> => comparison('<',  field, value);
+export const lte = <F extends PrimitiveFieldName>(field: F, value: FieldValue<F>): ComparisonPredicate<F> => comparison('<=', field, value);
+
+// ─── Range ───
+
+export function between<F extends PrimitiveFieldName>(
+    field: F,
+    from:  FieldValue<F>,
+    to:    FieldValue<F>,
+): BetweenPredicate<F> {
+    return { kind: 'between', field, from, to };
+}
+
+export function inList<F extends PrimitiveFieldName>(
+    field:  F,
+    values: FieldValue<F>[],
+): InPredicate<F> {
+    return { kind: 'in', field, values };
+}
+
+export function notIn<F extends PrimitiveFieldName>(
+    field:  F,
+    values: FieldValue<F>[],
+): InPredicate<F> {
+    return { kind: 'in', field, values, negate: true };
+}
+
+// ─── String pattern ───
+
+export function like<F extends StringFieldName>(field: F, pattern: string): LikePredicate<F> {
+    return { kind: 'like', field, pattern };
+}
+
+export function notLike<F extends StringFieldName>(field: F, pattern: string): LikePredicate<F> {
+    return { kind: 'like', field, pattern, negate: true };
+}
+
+// ─── Null ───
+
+export function isNull(field: FieldName): NullPredicate {
+    return { kind: 'null', field, negate: false };
+}
+
+export function isNotNull(field: FieldName): NullPredicate {
+    return { kind: 'null', field, negate: true };
+}
+
+// ─── Full-text / relevance ───
+
+export function matchQuery<F extends StringFieldName>(
+    field:    F,
+    query:    string,
+    options?: MatchQueryOptions,
+): MatchQueryPredicate<F> {
+    return { kind: 'match_query', field, query, options };
+}
+
+export function multiMatch(
+    fields:   StringFieldName[],
+    query:    string,
+    options?: MultiMatchOptions,
+): MultiMatchPredicate {
+    return { kind: 'multi_match', fields, query, options };
+}
+
+export function wildcardQuery<F extends StringFieldName>(
+    field:  F,
+    query:  string,
+    boost?: number,
+): WildcardQueryPredicate<F> {
+    return { kind: 'wildcard_query', field, query, boost };
+}
+
+/**
+ * SCORE(MATCH_QUERY(field, 'query'), boost)
+ * Filters by relevance score; used in WHERE to rank-filter results.
+ */
+export function score(
+    matchExpr: MatchQueryPredicate,
+    boost?:    number,
+): ScorePredicate {
+    return { kind: 'score', matchExpr, boost };
+}
+
+// ─── Logical connectives ───
+
+/**
+ * Combines predicates with AND.
+ * Accepts 1..n predicates; a single predicate is returned as-is.
+ * When appending to an existing AndPredicate (as `andWhere` does), the
+ * builder flattens operands to avoid deep nesting.
+ */
+export function and(...operands: [Predicate, ...Predicate[]]): Predicate {
+    if (operands.length === 1) return operands[0];
+    return { kind: 'and', operands };
+}
+
+/** Combines predicates with OR. Single predicate is returned as-is. */
+export function or(...operands: [Predicate, ...Predicate[]]): Predicate {
+    if (operands.length === 1) return operands[0];
+    return { kind: 'or', operands };
+}
+
+export function not(expr: Predicate): NotPredicate {
+    return { kind: 'not', expr };
+}

--- a/libs/api/opensearch-query-builder/src/lib/query-builder.ts
+++ b/libs/api/opensearch-query-builder/src/lib/query-builder.ts
@@ -1,0 +1,229 @@
+/**
+ * Fluent SQL query builder for OpenSearch training-event indices.
+ *
+ * Usage:
+ *
+ *   const sql = new QueryBuilder('crczp.events.trainings.*')
+ *     .select(field('type'), as(count('*'), 'cnt'))
+ *     .where(and(
+ *       eq('training_run_id', 42),
+ *       inList('type', [EventType.LevelStarted, EventType.LevelCompleted]),
+ *     ))
+ *     .groupBy(field('type'))
+ *     .orderBy(field('type'))
+ *     .limit(100)
+ *     .toSQL();
+ */
+
+import type { AnyExpr, JoinClause, JoinType, OrderByElement, Predicate, QueryState, SelectElement } from './ast';
+import { and, or } from './predicates';
+import { toSQL } from './sql';
+
+const emptyState = (): Omit<QueryState, 'index'> => ({
+    distinct: false,
+    select:   ['*'],
+    joins:    [],
+    where:    null,
+    groupBy:  [],
+    having:   null,
+    orderBy:  [],
+    limit:    null,
+    offset:   null,
+});
+
+export class QueryBuilder {
+    private state: QueryState;
+
+    constructor(index: string, alias?: string) {
+        this.state = { ...emptyState(), index, alias };
+    }
+
+    // ─── SELECT ───
+
+    /** Replace the entire SELECT list. */
+    select(...elements: SelectElement[]): this {
+        this.state = { ...this.state, select: elements };
+        return this;
+    }
+
+    /** Append to the current SELECT list (removes a leading `*` if present). */
+    addSelect(...elements: SelectElement[]): this {
+        const current = this.state.select.filter((e) => e !== '*');
+        this.state = { ...this.state, select: [...current, ...elements] };
+        return this;
+    }
+
+    selectAll(): this {
+        this.state = { ...this.state, select: ['*'] };
+        return this;
+    }
+
+    distinct(on = true): this {
+        this.state = { ...this.state, distinct: on };
+        return this;
+    }
+
+    // ─── JOIN ───
+    // OpenSearch SQL only supports two-index joins. Additional join() calls will
+    // be serialised but will produce invalid SQL at runtime.
+
+    join(index: string, alias: string, on: JoinClause['on']): this {
+        return this.pushJoin('INNER', index, alias, on);
+    }
+
+    leftJoin(index: string, alias: string, on: JoinClause['on']): this {
+        return this.pushJoin('LEFT', index, alias, on);
+    }
+
+    /** Cross join has no ON condition. */
+    crossJoin(index: string, alias: string): this {
+        return this.pushJoin('CROSS', index, alias, undefined);
+    }
+
+    private pushJoin(
+        type:  JoinType,
+        index: string,
+        alias: string,
+        on:    JoinClause['on'],
+    ): this {
+        const clause: JoinClause = { type, index, alias, on };
+        this.state = { ...this.state, joins: [...this.state.joins, clause] };
+        return this;
+    }
+
+    // ─── WHERE ───
+
+    /** Replace the WHERE predicate. */
+    where(predicate: Predicate): this {
+        this.state = { ...this.state, where: predicate };
+        return this;
+    }
+
+    /**
+     * Append an AND condition.
+     * Flattens into an existing AndPredicate to avoid unnecessary nesting.
+     */
+    andWhere(predicate: Predicate): this {
+        const w = this.state.where;
+        if (!w) {
+            this.state = { ...this.state, where: predicate };
+        } else if (w.kind === 'and') {
+            this.state = {
+                ...this.state,
+                where: { kind: 'and', operands: [...w.operands, predicate] },
+            };
+        } else {
+            this.state = { ...this.state, where: and(w, predicate) };
+        }
+        return this;
+    }
+
+    /** Append an OR condition. Flattens into an existing OrPredicate. */
+    orWhere(predicate: Predicate): this {
+        const w = this.state.where;
+        if (!w) {
+            this.state = { ...this.state, where: predicate };
+        } else if (w.kind === 'or') {
+            this.state = {
+                ...this.state,
+                where: { kind: 'or', operands: [...w.operands, predicate] },
+            };
+        } else {
+            this.state = { ...this.state, where: or(w, predicate) };
+        }
+        return this;
+    }
+
+    // ─── GROUP BY ───
+
+    /** Replace the GROUP BY list. */
+    groupBy(...exprs: AnyExpr[]): this {
+        this.state = { ...this.state, groupBy: exprs };
+        return this;
+    }
+
+    addGroupBy(...exprs: AnyExpr[]): this {
+        this.state = { ...this.state, groupBy: [...this.state.groupBy, ...exprs] };
+        return this;
+    }
+
+    // ─── HAVING ───
+
+    having(predicate: Predicate): this {
+        this.state = { ...this.state, having: predicate };
+        return this;
+    }
+
+    andHaving(predicate: Predicate): this {
+        const h = this.state.having;
+        if (!h) {
+            this.state = { ...this.state, having: predicate };
+        } else if (h.kind === 'and') {
+            this.state = {
+                ...this.state,
+                having: { kind: 'and', operands: [...h.operands, predicate] },
+            };
+        } else {
+            this.state = { ...this.state, having: and(h, predicate) };
+        }
+        return this;
+    }
+
+    // ─── ORDER BY ───
+
+    /**
+     * Append an ORDER BY element.
+     * `nulls` controls null ordering:
+     *   'FIRST' → emits `IS NOT NULL` (OpenSearch puts nulls before non-nulls)
+     *   'LAST'  → emits `IS NULL`     (explicitly states the default)
+     *   omitted → no null-ordering clause
+     */
+    orderBy(
+        expr:      AnyExpr,
+        direction: 'ASC' | 'DESC' = 'ASC',
+        nulls?:    'FIRST' | 'LAST',
+    ): this {
+        const element: OrderByElement = { expr, direction, nulls };
+        this.state = { ...this.state, orderBy: [...this.state.orderBy, element] };
+        return this;
+    }
+
+    // ─── LIMIT / OFFSET ───
+
+    limit(size: number): this {
+        this.state = { ...this.state, limit: size };
+        return this;
+    }
+
+    offset(n: number): this {
+        this.state = { ...this.state, offset: n };
+        return this;
+    }
+
+    // ─── Output ───
+
+    toSQL(): string {
+        return toSQL(this.state);
+    }
+
+    /** Expose the underlying state for inspection or custom serialisation. */
+    getState(): Readonly<QueryState> {
+        return this.state;
+    }
+
+    /**
+     * Produce an independent copy of this builder.
+     * Useful for building query variations from a shared base.
+     */
+    clone(): QueryBuilder {
+        const qb = new QueryBuilder(this.state.index, this.state.alias);
+        qb.state = {
+            ...this.state,
+            select:  [...this.state.select],
+            joins:   [...this.state.joins],
+            groupBy: [...this.state.groupBy],
+            orderBy: [...this.state.orderBy],
+        };
+        return qb;
+    }
+}

--- a/libs/api/opensearch-query-builder/src/lib/query-builder.ts
+++ b/libs/api/opensearch-query-builder/src/lib/query-builder.ts
@@ -15,26 +15,35 @@
  *     .toSQL();
  */
 
-import type { AnyExpr, JoinClause, JoinType, OrderByElement, Predicate, QueryState, SelectElement } from './ast';
+import type {
+    AnyExpr,
+    JoinClause,
+    JoinType,
+    OrderByElement,
+    Predicate,
+    QueryState,
+    SelectElement,
+} from './ast';
 import { and, or } from './predicates';
 import { toSQL } from './sql';
+import { TrainingIndex } from './schema';
 
 const emptyState = (): Omit<QueryState, 'index'> => ({
     distinct: false,
-    select:   ['*'],
-    joins:    [],
-    where:    null,
-    groupBy:  [],
-    having:   null,
-    orderBy:  [],
-    limit:    null,
-    offset:   null,
+    select: ['*'],
+    joins: [],
+    where: null,
+    groupBy: [],
+    having: null,
+    orderBy: [],
+    limit: null,
+    offset: null,
 });
 
 export class QueryBuilder {
     private state: QueryState;
 
-    constructor(index: string, alias?: string) {
+    constructor(index: TrainingIndex, alias?: string) {
         this.state = { ...emptyState(), index, alias };
     }
 
@@ -202,7 +211,7 @@ export class QueryBuilder {
 
     // ─── Output ───
 
-    toSQL(): string {
+    build(): string {
         return toSQL(this.state);
     }
 

--- a/libs/api/opensearch-query-builder/src/lib/schema.ts
+++ b/libs/api/opensearch-query-builder/src/lib/schema.ts
@@ -11,20 +11,20 @@
 // ─── Event taxonomy ───
 
 export const EventType = {
-    TrainingRunStarted:      'cz.cyberrange.platform.events.trainings.TrainingRunStarted',
-    TrainingRunResumed:      'cz.cyberrange.platform.events.trainings.TrainingRunResumed',
-    TrainingRunEnded:        'cz.cyberrange.platform.events.trainings.TrainingRunEnded',
-    LevelStarted:            'cz.cyberrange.platform.events.trainings.LevelStarted',
-    LevelCompleted:          'cz.cyberrange.platform.events.trainings.LevelCompleted',
-    CorrectAnswerSubmitted:  'cz.cyberrange.platform.events.trainings.CorrectAnswerSubmitted',
-    CorrectFlagSubmitted:    'cz.cyberrange.platform.events.trainings.CorrectFlagSubmitted',
-    WrongAnswerSubmitted:    'cz.cyberrange.platform.events.trainings.WrongAnswerSubmitted',
-    WrongFlagSubmitted:      'cz.cyberrange.platform.events.trainings.WrongFlagSubmitted',
-    CorrectPasskeySubmitted: 'cz.cyberrange.platform.events.trainings.CorrectPasskeySubmitted',
-    WrongPasskeySubmitted:   'cz.cyberrange.platform.events.trainings.WrongPasskeySubmitted',
-    HintTaken:               'cz.cyberrange.platform.events.trainings.HintTaken',
-    SolutionDisplayed:       'cz.cyberrange.platform.events.trainings.SolutionDisplayed',
-    AssessmentAnswers:       'cz.cyberrange.platform.events.trainings.AssessmentAnswers',
+    TrainingRunStarted:      'cz.cyberrange.platform.training.opensearch.model.TrainingRunStarted',
+    TrainingRunResumed:      'cz.cyberrange.platform.training.opensearch.model.TrainingRunResumed',
+    TrainingRunEnded:        'cz.cyberrange.platform.training.opensearch.model.TrainingRunEnded',
+    LevelStarted:            'cz.cyberrange.platform.training.opensearch.model.LevelStarted',
+    LevelCompleted:          'cz.cyberrange.platform.training.opensearch.model.LevelCompleted',
+    CorrectAnswerSubmitted:  'cz.cyberrange.platform.training.opensearch.model.CorrectAnswerSubmitted',
+    CorrectFlagSubmitted:    'cz.cyberrange.platform.training.opensearch.model.CorrectFlagSubmitted',
+    WrongAnswerSubmitted:    'cz.cyberrange.platform.training.opensearch.model.WrongAnswerSubmitted',
+    WrongFlagSubmitted:      'cz.cyberrange.platform.training.opensearch.model.WrongFlagSubmitted',
+    CorrectPasskeySubmitted: 'cz.cyberrange.platform.training.opensearch.model.CorrectPasskeySubmitted',
+    WrongPasskeySubmitted:   'cz.cyberrange.platform.training.opensearch.model.WrongPasskeySubmitted',
+    HintTaken:               'cz.cyberrange.platform.training.opensearch.model.HintTaken',
+    SolutionDisplayed:       'cz.cyberrange.platform.training.opensearch.model.SolutionDisplayed',
+    AssessmentAnswers:       'cz.cyberrange.platform.training.opensearch.model.AssessmentAnswers',
 } as const;
 
 export type EventTypeName = (typeof EventType)[keyof typeof EventType];
@@ -32,10 +32,35 @@ export type LevelType = 'INFO' | 'ACCESS' | 'TRAINING' | 'ASSESSMENT';
 
 // ─── Index pattern ───
 
-/** Wildcard (all runs) or a fully-qualified single-run index. */
+/** Stands in for any field value in an OpenSearch index pattern. */
+type IndexWildcard = '*';
+
+type PoolSegment       = `pool=${number       | IndexWildcard}`;
+type SandboxSegment    = `sandbox=${string    | IndexWildcard}`;
+type DefinitionSegment = `definition=${number | IndexWildcard}`;
+type InstanceSegment   = `instance=${number   | IndexWildcard}`;
+type RunSegment        = `run=${number        | IndexWildcard}`;
+
+/**
+ * Valid OpenSearch index selector for training events.
+ *
+ * Each member represents the index pattern up to a given field, with the
+ * remaining fields replaced by a `.*` wildcard suffix. Fields themselves can
+ * be concrete values or `*`. The union is ordered: earlier members are broader
+ * selectors, the last member is the fully-qualified pattern.
+ *
+ * Examples:
+ *   crczp.events.trainings.*
+ *   crczp.events.trainings.pool=10.*
+ *   crczp.events.trainings.pool=10.sandbox=*.definition=1.instance=2.run=*
+ */
 export type TrainingIndex =
-    | 'crczp.events.trainings.*'
-    | `crczp.events.trainings.pool=${number}.sandbox=${string}.definition=${number}.instance=${number}.run=${number}`;
+    | `crczp.events.trainings.*`
+    | `crczp.events.trainings.${PoolSegment}.*`
+    | `crczp.events.trainings.${PoolSegment}.${SandboxSegment}.*`
+    | `crczp.events.trainings.${PoolSegment}.${SandboxSegment}.${DefinitionSegment}.*`
+    | `crczp.events.trainings.${PoolSegment}.${SandboxSegment}.${DefinitionSegment}.${InstanceSegment}.*`
+    | `crczp.events.trainings.${PoolSegment}.${SandboxSegment}.${DefinitionSegment}.${InstanceSegment}.${RunSegment}`;
 
 // ─── Field type map ───
 

--- a/libs/api/opensearch-query-builder/src/lib/schema.ts
+++ b/libs/api/opensearch-query-builder/src/lib/schema.ts
@@ -1,0 +1,112 @@
+/**
+ * OpenSearch training event schema.
+ *
+ * The core design choice: a flat `FieldTypeMap` (field name → TS type) rather
+ * than a union of per-event interface types. The union approach has a fatal
+ * flaw — `keyof (A | B)` in TypeScript yields only the keys *common* to all
+ * members, silently dropping every event-specific field. The flat map avoids
+ * this entirely and scales trivially when new event types are added.
+ */
+
+// ─── Event taxonomy ───
+
+export const EventType = {
+    TrainingRunStarted:      'cz.cyberrange.platform.events.trainings.TrainingRunStarted',
+    TrainingRunResumed:      'cz.cyberrange.platform.events.trainings.TrainingRunResumed',
+    TrainingRunEnded:        'cz.cyberrange.platform.events.trainings.TrainingRunEnded',
+    LevelStarted:            'cz.cyberrange.platform.events.trainings.LevelStarted',
+    LevelCompleted:          'cz.cyberrange.platform.events.trainings.LevelCompleted',
+    CorrectAnswerSubmitted:  'cz.cyberrange.platform.events.trainings.CorrectAnswerSubmitted',
+    CorrectFlagSubmitted:    'cz.cyberrange.platform.events.trainings.CorrectFlagSubmitted',
+    WrongAnswerSubmitted:    'cz.cyberrange.platform.events.trainings.WrongAnswerSubmitted',
+    WrongFlagSubmitted:      'cz.cyberrange.platform.events.trainings.WrongFlagSubmitted',
+    CorrectPasskeySubmitted: 'cz.cyberrange.platform.events.trainings.CorrectPasskeySubmitted',
+    WrongPasskeySubmitted:   'cz.cyberrange.platform.events.trainings.WrongPasskeySubmitted',
+    HintTaken:               'cz.cyberrange.platform.events.trainings.HintTaken',
+    SolutionDisplayed:       'cz.cyberrange.platform.events.trainings.SolutionDisplayed',
+    AssessmentAnswers:       'cz.cyberrange.platform.events.trainings.AssessmentAnswers',
+} as const;
+
+export type EventTypeName = (typeof EventType)[keyof typeof EventType];
+export type LevelType = 'INFO' | 'ACCESS' | 'TRAINING' | 'ASSESSMENT';
+
+// ─── Index pattern ───
+
+/** Wildcard (all runs) or a fully-qualified single-run index. */
+export type TrainingIndex =
+    | 'crczp.events.trainings.*'
+    | `crczp.events.trainings.pool=${number}.sandbox=${string}.definition=${number}.instance=${number}.run=${number}`;
+
+// ─── Field type map ───
+
+/**
+ * Every known field name mapped to its TypeScript value type.
+ * Event-specific fields that are absent on some events still appear here —
+ * callers are responsible for only querying fields that exist for the events
+ * they care about (matching on `type` first is the usual pattern).
+ */
+export type FieldTypeMap = {
+    // AbstractEvent — present in every event
+    type:                         string;
+    timestamp:                    number;
+    sandbox_id:                   string;
+    pool_id:                      number;
+    training_definition_id:       number;
+    training_instance_id:         number;
+    training_run_id:              number;
+    training_time:                number;
+    level:                        number;
+    level_order:                  number;
+    user_ref_id:                  number;
+    actual_score_in_level:        number;
+    total_training_level_score:   number;
+    total_assessment_level_score: number;
+
+    // TrainingRunEnded
+    start_time: number;
+    end_time:   number;
+
+    // LevelStarted
+    level_type:  LevelType;
+    level_title: string;
+    max_score:   number;
+
+    // CorrectAnswerSubmitted / WrongAnswerSubmitted
+    answer_content: string;
+    count:          number;
+
+    // CorrectPasskeySubmitted / WrongPasskeySubmitted
+    passkey_content: string;
+
+    // HintTaken
+    hint_id:             number;
+    hint_title:          string;
+    hint_penalty_points: number;
+
+    // SolutionDisplayed
+    penalty_points: number;
+
+    // AssessmentAnswers — dynamic JSON payload, not safe to filter on directly
+    answers: Record<string, unknown>;
+};
+
+export type FieldName = keyof FieldTypeMap;
+export type FieldValue<F extends FieldName> = FieldTypeMap[F];
+
+// ─── Derived field-name subsets ───
+// Used to enforce meaningful constraints on predicates at the type level.
+
+/** Fields whose values can appear as SQL literals (string | number | boolean). */
+export type PrimitiveFieldName = {
+    [K in FieldName]: FieldTypeMap[K] extends string | number | boolean ? K : never;
+}[FieldName];
+
+/** Fields with string values — valid targets for LIKE / MATCH_QUERY / WILDCARD_QUERY. */
+export type StringFieldName = {
+    [K in FieldName]: FieldTypeMap[K] extends string ? K : never;
+}[FieldName];
+
+/** Fields with numeric values — valid targets for arithmetic comparisons. */
+export type NumericFieldName = {
+    [K in FieldName]: FieldTypeMap[K] extends number ? K : never;
+}[FieldName];

--- a/libs/api/opensearch-query-builder/src/lib/sql.ts
+++ b/libs/api/opensearch-query-builder/src/lib/sql.ts
@@ -1,0 +1,294 @@
+/**
+ * OpenSearch SQL serialiser — converts a QueryState AST to a SQL string.
+ *
+ * Clause execution order (not emit order):
+ *   FROM → WHERE → GROUP BY → HAVING → SELECT → ORDER BY → LIMIT
+ *
+ * Emit order (as required by the SQL syntax):
+ *   SELECT [DISTINCT] …
+ *   FROM index [alias]
+ *   [JOIN …]
+ *   [WHERE …]
+ *   [GROUP BY …]
+ *   [HAVING …]
+ *   [ORDER BY …]
+ *   [LIMIT [offset,] size]
+ */
+
+import type {
+    AggregateExpr,
+    AnyExpr,
+    CastExpr,
+    FunctionExpr,
+    JoinClause,
+    LikePredicate,
+    MatchQueryPredicate,
+    MultiMatchPredicate,
+    NullPredicate,
+    OrderByElement,
+    Predicate,
+    QueryState,
+    ScorePredicate,
+    SelectElement,
+    WildcardQueryPredicate,
+} from './ast';
+
+// Public entry point
+
+export function toSQL(state: QueryState): string {
+    const clauses: string[] = [];
+
+    // SELECT [DISTINCT]
+    const selectList = state.select.map(serializeSelectElement).join(', ');
+    clauses.push(`SELECT${state.distinct ? ' DISTINCT' : ''} ${selectList}`);
+
+    // FROM
+    const fromTarget = state.alias
+        ? `${state.index} ${state.alias}`
+        : state.index;
+    clauses.push(`FROM ${fromTarget}`);
+
+    // JOIN(s)
+    for (const join of state.joins) {
+        clauses.push(serializeJoin(join));
+    }
+
+    // WHERE
+    if (state.where) {
+        clauses.push(`WHERE ${serializePredicate(state.where)}`);
+    }
+
+    // GROUP BY
+    if (state.groupBy.length > 0) {
+        clauses.push(`GROUP BY ${state.groupBy.map(serializeExpr).join(', ')}`);
+    }
+
+    // HAVING
+    if (state.having) {
+        clauses.push(`HAVING ${serializePredicate(state.having)}`);
+    }
+
+    // ORDER BY
+    if (state.orderBy.length > 0) {
+        clauses.push(`ORDER BY ${state.orderBy.map(serializeOrderBy).join(', ')}`);
+    }
+
+    // LIMIT [offset,] size
+    if (state.limit !== null) {
+        clauses.push(
+            state.offset !== null
+                ? `LIMIT ${state.offset}, ${state.limit}`
+                : `LIMIT ${state.limit}`,
+        );
+    }
+
+    return clauses.join('\n');
+}
+
+// SELECT element
+
+function serializeSelectElement(el: SelectElement): string {
+    if (el === '*') return '*';
+    if (el.kind === 'aliased') return `${serializeExpr(el.expr)} AS ${quoteIdentifier(el.alias)}`;
+    return serializeExpr(el);
+}
+
+// Expressions
+
+function serializeExpr(expr: AnyExpr): string {
+    switch (expr.kind) {
+        case 'field':
+            return quoteFieldName(expr.name);
+
+        case 'literal':
+            return serializeLiteral(expr.value);
+
+        case 'arithmetic':
+            // Parenthesise to preserve explicit operator precedence from the builder.
+            return `(${serializeExpr(expr.left)} ${expr.op} ${serializeExpr(expr.right)})`;
+
+        case 'function':
+            return serializeFunctionExpr(expr);
+
+        case 'aggregate':
+            return serializeAggregateExpr(expr);
+
+        case 'cast':
+            return serializeCastExpr(expr);
+    }
+}
+
+function serializeLiteral(value: string | number | boolean | null): string {
+    if (value === null)             return 'NULL';
+    if (typeof value === 'boolean') return value ? 'TRUE' : 'FALSE';
+    if (typeof value === 'number')  return String(value);
+    // String — escape embedded single quotes by doubling them.
+    return `'${value.replace(/'/g, "''")}'`;
+}
+
+function serializeFunctionExpr(expr: FunctionExpr): string {
+    return `${expr.name}(${expr.args.map(serializeExpr).join(', ')})`;
+}
+
+function serializeAggregateExpr(expr: AggregateExpr): string {
+    const arg      = expr.arg === '*' ? '*' : serializeExpr(expr.arg);
+    const distinct = expr.distinct ? 'DISTINCT ' : '';
+    return `${expr.fn}(${distinct}${arg})`;
+}
+
+function serializeCastExpr(expr: CastExpr): string {
+    return `CAST(${serializeExpr(expr.expr)} AS ${expr.targetType})`;
+}
+
+// Predicates
+
+function serializePredicate(pred: Predicate): string {
+    switch (pred.kind) {
+        case 'comparison':
+            return `${quoteFieldName(pred.field)} ${pred.op} ${serializeLiteral(pred.value as string | number | boolean | null)}`;
+
+        case 'between':
+            return (
+                `${quoteFieldName(pred.field)} BETWEEN ` +
+                `${serializeLiteral(pred.from as string | number | boolean | null)} AND ` +
+                `${serializeLiteral(pred.to as string | number | boolean | null)}`
+            );
+
+        case 'in': {
+            const values = pred.values
+                .map((v) => serializeLiteral(v as string | number | boolean | null))
+                .join(', ');
+            return `${quoteFieldName(pred.field)} ${pred.negate ? 'NOT IN' : 'IN'} (${values})`;
+        }
+
+        case 'like':
+            return serializeLikePredicate(pred);
+
+        case 'null':
+            return serializeNullPredicate(pred);
+
+        case 'match_query':
+            return serializeMatchQuery(pred);
+
+        case 'multi_match':
+            return serializeMultiMatch(pred);
+
+        case 'wildcard_query':
+            return serializeWildcardQuery(pred);
+
+        case 'score':
+            return serializeScore(pred);
+
+        case 'and':
+            return `(${pred.operands.map(serializePredicate).join(' AND ')})`;
+
+        case 'or':
+            return `(${pred.operands.map(serializePredicate).join(' OR ')})`;
+
+        case 'not':
+            return `NOT (${serializePredicate(pred.expr)})`;
+    }
+}
+
+function serializeLikePredicate(pred: LikePredicate): string {
+    // LIKE patterns are passed as-is; the caller owns wildcard escaping.
+    const op = pred.negate ? 'NOT LIKE' : 'LIKE';
+    return `${quoteFieldName(pred.field)} ${op} '${pred.pattern.replace(/'/g, "''")}'`;
+}
+
+function serializeNullPredicate(pred: NullPredicate): string {
+    return `${quoteFieldName(pred.field)} IS ${pred.negate ? 'NOT ' : ''}NULL`;
+}
+
+function serializeMatchQuery(pred: MatchQueryPredicate): string {
+    // MATCH_QUERY(field, 'query'[, option=value]*)
+    const args: string[] = [quoteFieldName(pred.field), serializeLiteral(pred.query)];
+    if (pred.options?.analyzer !== undefined) {
+        args.push(`analyzer=${serializeLiteral(pred.options.analyzer)}`);
+    }
+    if (pred.options?.boost !== undefined) {
+        args.push(`boost=${pred.options.boost}`);
+    }
+    return `MATCH_QUERY(${args.join(', ')})`;
+}
+
+function serializeMultiMatch(pred: MultiMatchPredicate): string {
+    // MULTI_MATCH('query'=...[, 'fields'=...][, option=value]*)
+    // Note: 'query' and 'fields' keys use quoted names per the OpenSearch SQL spec.
+    const args: string[] = [`'query'=${serializeLiteral(pred.query)}`];
+    if (pred.fields.length > 0) {
+        args.push(`'fields'=${serializeLiteral(pred.fields.join(','))}`);
+    }
+    const opts = pred.options;
+    if (opts) {
+        if (opts.analyzer !== undefined)    args.push(`analyzer=${serializeLiteral(opts.analyzer)}`);
+        if (opts.boost !== undefined)       args.push(`boost=${opts.boost}`);
+        if (opts.slop !== undefined)        args.push(`slop=${opts.slop}`);
+        if (opts.type !== undefined)        args.push(`type=${serializeLiteral(opts.type)}`);
+        if (opts.tie_breaker !== undefined) args.push(`tie_breaker=${opts.tie_breaker}`);
+        if (opts.operator !== undefined)    args.push(`operator=${serializeLiteral(opts.operator)}`);
+    }
+    return `MULTI_MATCH(${args.join(', ')})`;
+}
+
+function serializeWildcardQuery(pred: WildcardQueryPredicate): string {
+    // WILDCARD_QUERY(field, 'query'[, boost=n])
+    const args: string[] = [quoteFieldName(pred.field), serializeLiteral(pred.query)];
+    if (pred.boost !== undefined) args.push(`boost=${pred.boost}`);
+    return `WILDCARD_QUERY(${args.join(', ')})`;
+}
+
+function serializeScore(pred: ScorePredicate): string {
+    // SCORE(MATCH_QUERY(field, 'query')[, boost])
+    const boost = pred.boost !== undefined ? `, ${pred.boost}` : '';
+    return `SCORE(${serializeMatchQuery(pred.matchExpr)}${boost})`;
+}
+
+// ORDER BY
+
+function serializeOrderBy(el: OrderByElement): string {
+    let sql = serializeExpr(el.expr);
+
+    // OpenSearch SQL uses `IS [NOT] NULL` before ASC/DESC to control null placement.
+    // Default behaviour is NULLS LAST, so NULLS LAST maps to `IS NULL` (explicit default).
+    if (el.nulls === 'FIRST') sql += ' IS NOT NULL';
+    else if (el.nulls === 'LAST') sql += ' IS NULL';
+
+    sql += ` ${el.direction}`;
+    return sql;
+}
+
+// JOIN
+
+function serializeJoin(join: JoinClause): string {
+    const keyword =
+        join.type === 'LEFT'  ? 'LEFT JOIN' :
+        join.type === 'CROSS' ? 'JOIN'       : // CROSS = JOIN without ON
+        'JOIN';                                  // INNER
+
+    let sql = `${keyword} ${join.index} ${join.alias}`;
+
+    if (join.type !== 'CROSS' && join.on && join.on.length > 0) {
+        const conditions = join.on.map((c) => `${c.left} = ${c.right}`).join(' AND ');
+        sql += ` ON ${conditions}`;
+    }
+
+    return sql;
+}
+
+// Identifier quoting
+
+/**
+ * Backtick-quote a field name if it contains characters outside `[a-zA-Z0-9_.]`.
+ * The dot is kept unquoted because OpenSearch SQL uses it as the nested-field
+ * separator (`syslog.severity`). Characters like `@` and `-` must be quoted
+ * (`syslog.@timestamp`, `syslog.fromhost-ip`).
+ */
+function quoteFieldName(name: string): string {
+    return /[^a-zA-Z0-9_.]/.test(name) ? `\`${name}\`` : name;
+}
+
+/** Backtick-quote alias / identifier strings that need it. */
+function quoteIdentifier(name: string): string {
+    return /[^a-zA-Z0-9_]/.test(name) ? `\`${name}\`` : name;
+}

--- a/libs/api/opensearch-query-builder/src/tests/queries.spec.ts
+++ b/libs/api/opensearch-query-builder/src/tests/queries.spec.ts
@@ -56,7 +56,7 @@ const L = (...lines: string[]) => lines.join('\n');
 
 describe('SELECT shapes', () => {
     it('defaults to SELECT * with no select() call', () => {
-        expect(new QueryBuilder('crczp.events.trainings.*').toSQL()).toBe(L(
+        expect(new QueryBuilder('crczp.events.trainings.*').build()).toBe(L(
             'SELECT *',
             'FROM crczp.events.trainings.*',
         ));
@@ -66,7 +66,7 @@ describe('SELECT shapes', () => {
         expect(
             new QueryBuilder('crczp.events.trainings.*')
                 .select(field('training_run_id'), field('type'), field('timestamp'))
-                .toSQL(),
+                .build(),
         ).toBe(L(
             'SELECT training_run_id, type, timestamp',
             'FROM crczp.events.trainings.*',
@@ -77,7 +77,7 @@ describe('SELECT shapes', () => {
         expect(
             new QueryBuilder('crczp.events.trainings.*')
                 .select(field('training_run_id'), as(count('*'), 'cnt'))
-                .toSQL(),
+                .build(),
         ).toBe(L(
             'SELECT training_run_id, COUNT(*) AS cnt',
             'FROM crczp.events.trainings.*',
@@ -89,7 +89,7 @@ describe('SELECT shapes', () => {
             new QueryBuilder('crczp.events.trainings.*')
                 .select(field('user_ref_id'))
                 .distinct()
-                .toSQL(),
+                .build(),
         ).toBe(L(
             'SELECT DISTINCT user_ref_id',
             'FROM crczp.events.trainings.*',
@@ -101,7 +101,7 @@ describe('SELECT shapes', () => {
             new QueryBuilder('crczp.events.trainings.*')
                 .addSelect(field('type'))
                 .addSelect(field('timestamp'))
-                .toSQL(),
+                .build(),
         ).toBe(L(
             'SELECT type, timestamp',
             'FROM crczp.events.trainings.*',
@@ -113,7 +113,7 @@ describe('SELECT shapes', () => {
             new QueryBuilder('crczp.events.trainings.*')
                 .select(field('type'))
                 .selectAll()
-                .toSQL(),
+                .build(),
         ).toBe(L(
             'SELECT *',
             'FROM crczp.events.trainings.*',
@@ -124,7 +124,7 @@ describe('SELECT shapes', () => {
         expect(
             new QueryBuilder('crczp.events.trainings.*', 'e')
                 .select(field('type'), field('timestamp'))
-                .toSQL(),
+                .build(),
         ).toBe(L(
             'SELECT type, timestamp',
             'FROM crczp.events.trainings.* e',
@@ -140,7 +140,7 @@ describe('WHERE conditions', () => {
             new QueryBuilder('crczp.events.trainings.*')
                 .select(field('type'), field('level'))
                 .where(eq('training_run_id', 42))
-                .toSQL(),
+                .build(),
         ).toBe(L(
             'SELECT type, level',
             'FROM crczp.events.trainings.*',
@@ -153,7 +153,7 @@ describe('WHERE conditions', () => {
             new QueryBuilder('crczp.events.trainings.*')
                 .select('*')
                 .where(eq('type', EventType.LevelStarted))
-                .toSQL(),
+                .build(),
         ).toBe(L(
             'SELECT *',
             'FROM crczp.events.trainings.*',
@@ -166,7 +166,7 @@ describe('WHERE conditions', () => {
             new QueryBuilder('crczp.events.trainings.*')
                 .select(field('training_run_id'), field('type'))
                 .where(neq('type', EventType.AssessmentAnswers))
-                .toSQL(),
+                .build(),
         ).toBe(L(
             'SELECT training_run_id, type',
             'FROM crczp.events.trainings.*',
@@ -179,7 +179,7 @@ describe('WHERE conditions', () => {
             new QueryBuilder('crczp.events.trainings.*')
                 .select(field('type'), field('timestamp'))
                 .where(between('timestamp', 1700000000000, 1800000000000))
-                .toSQL(),
+                .build(),
         ).toBe(L(
             'SELECT type, timestamp',
             'FROM crczp.events.trainings.*',
@@ -192,7 +192,7 @@ describe('WHERE conditions', () => {
             new QueryBuilder('crczp.events.trainings.*')
                 .select(field('type'), field('training_run_id'), field('actual_score_in_level'))
                 .where(inList('type', [EventType.LevelStarted, EventType.LevelCompleted]))
-                .toSQL(),
+                .build(),
         ).toBe(L(
             'SELECT type, training_run_id, actual_score_in_level',
             'FROM crczp.events.trainings.*',
@@ -205,7 +205,7 @@ describe('WHERE conditions', () => {
             new QueryBuilder('crczp.events.trainings.*')
                 .select('*')
                 .where(notIn('level_order', [0, 9, 10]))
-                .toSQL(),
+                .build(),
         ).toBe(L(
             'SELECT *',
             'FROM crczp.events.trainings.*',
@@ -218,7 +218,7 @@ describe('WHERE conditions', () => {
             new QueryBuilder('crczp.events.trainings.*')
                 .select(field('training_run_id'), field('hint_title'))
                 .where(isNull('hint_title'))
-                .toSQL(),
+                .build(),
         ).toBe(L(
             'SELECT training_run_id, hint_title',
             'FROM crczp.events.trainings.*',
@@ -231,7 +231,7 @@ describe('WHERE conditions', () => {
             new QueryBuilder('crczp.events.trainings.*')
                 .select('*')
                 .where(isNotNull('level_title'))
-                .toSQL(),
+                .build(),
         ).toBe(L(
             'SELECT *',
             'FROM crczp.events.trainings.*',
@@ -244,7 +244,7 @@ describe('WHERE conditions', () => {
             new QueryBuilder('crczp.events.trainings.*')
                 .select(field('training_run_id'), field('type'))
                 .where(like('type', 'cz.cyberrange.platform.events.trainings.%'))
-                .toSQL(),
+                .build(),
         ).toBe(L(
             'SELECT training_run_id, type',
             'FROM crczp.events.trainings.*',
@@ -257,7 +257,7 @@ describe('WHERE conditions', () => {
             new QueryBuilder('crczp.events.trainings.*')
                 .select('*')
                 .where(notLike('level_title', 'Draft%'))
-                .toSQL(),
+                .build(),
         ).toBe(L(
             'SELECT *',
             'FROM crczp.events.trainings.*',
@@ -270,7 +270,7 @@ describe('WHERE conditions', () => {
             new QueryBuilder('crczp.events.trainings.*')
                 .select('*')
                 .where(matchQuery('level_title', 'network security', { analyzer: 'standard', boost: 1.5 }))
-                .toSQL(),
+                .build(),
         ).toBe(L(
             'SELECT *',
             'FROM crczp.events.trainings.*',
@@ -283,7 +283,7 @@ describe('WHERE conditions', () => {
             new QueryBuilder('crczp.events.trainings.*')
                 .select(field('training_run_id'), field('type'))
                 .where(multiMatch(['type', 'level_title'], 'security', { operator: 'AND' }))
-                .toSQL(),
+                .build(),
         ).toBe(L(
             'SELECT training_run_id, type',
             'FROM crczp.events.trainings.*',
@@ -296,7 +296,7 @@ describe('WHERE conditions', () => {
             new QueryBuilder('crczp.events.trainings.*')
                 .select('*')
                 .where(wildcardQuery('type', 'cz.cyberrange.*', 2))
-                .toSQL(),
+                .build(),
         ).toBe(L(
             'SELECT *',
             'FROM crczp.events.trainings.*',
@@ -309,7 +309,7 @@ describe('WHERE conditions', () => {
             new QueryBuilder('crczp.events.trainings.*')
                 .select(field('training_run_id'), field('level_title'))
                 .where(score(matchQuery('level_title', 'firewall'), 1.2))
-                .toSQL(),
+                .build(),
         ).toBe(L(
             'SELECT training_run_id, level_title',
             'FROM crczp.events.trainings.*',
@@ -325,7 +325,7 @@ describe('WHERE conditions', () => {
                     eq('training_run_id', 7),
                     eq('type', EventType.LevelCompleted),
                 ))
-                .toSQL(),
+                .build(),
         ).toBe(L(
             'SELECT type, level, actual_score_in_level',
             'FROM crczp.events.trainings.*',
@@ -341,7 +341,7 @@ describe('WHERE conditions', () => {
                     eq('type', EventType.CorrectAnswerSubmitted),
                     eq('type', EventType.WrongAnswerSubmitted),
                 ))
-                .toSQL(),
+                .build(),
         ).toBe(L(
             'SELECT training_run_id, type, timestamp',
             'FROM crczp.events.trainings.*',
@@ -354,7 +354,7 @@ describe('WHERE conditions', () => {
             new QueryBuilder('crczp.events.trainings.*')
                 .select('*')
                 .where(not(eq('level_type', 'ASSESSMENT')))
-                .toSQL(),
+                .build(),
         ).toBe(L(
             'SELECT *',
             'FROM crczp.events.trainings.*',
@@ -373,7 +373,7 @@ describe('WHERE conditions', () => {
                         eq('type', EventType.HintTaken),
                     ),
                 ))
-                .toSQL(),
+                .build(),
         ).toBe(L(
             'SELECT training_run_id, type, actual_score_in_level',
             'FROM crczp.events.trainings.*',
@@ -388,7 +388,7 @@ describe('WHERE conditions', () => {
                 .where(eq('training_run_id', 3))
                 .andWhere(eq('type', EventType.LevelCompleted))
                 .andWhere(gte('actual_score_in_level', 50))
-                .toSQL(),
+                .build(),
         ).toBe(L(
             'SELECT type, level',
             'FROM crczp.events.trainings.*',
@@ -403,7 +403,7 @@ describe('WHERE conditions', () => {
                 .where(eq('type', EventType.HintTaken))
                 .orWhere(eq('type', EventType.SolutionDisplayed))
                 .orWhere(eq('type', EventType.WrongAnswerSubmitted))
-                .toSQL(),
+                .build(),
         ).toBe(L(
             'SELECT *',
             'FROM crczp.events.trainings.*',
@@ -421,7 +421,7 @@ describe('field name quoting', () => {
             new QueryBuilder('crczp.events.trainings.*')
                 .select('*')
                 .where(eq('level_title', "Attacker's Toolkit"))
-                .toSQL(),
+                .build(),
         ).toBe(L(
             'SELECT *',
             'FROM crczp.events.trainings.*',
@@ -434,7 +434,7 @@ describe('field name quoting', () => {
             new QueryBuilder('crczp.events.trainings.*')
                 .select('*')
                 .where(like('level_title', "it's%"))
-                .toSQL(),
+                .build(),
         ).toBe(L(
             'SELECT *',
             'FROM crczp.events.trainings.*',
@@ -453,7 +453,7 @@ describe('GROUP BY and HAVING', () => {
                 .where(eq('type', EventType.LevelCompleted))
                 .groupBy(field('training_run_id'))
                 .orderBy(field('training_run_id'), 'ASC')
-                .toSQL(),
+                .build(),
         ).toBe(L(
             'SELECT training_run_id, COUNT(*) AS event_count',
             'FROM crczp.events.trainings.*',
@@ -471,7 +471,7 @@ describe('GROUP BY and HAVING', () => {
                 .groupBy(field('level'))
                 .having(gt('avg_score' as any, 60))
                 .orderBy(field('level'), 'ASC')
-                .toSQL(),
+                .build(),
         ).toBe(L(
             'SELECT level, AVG(actual_score_in_level) AS avg_score',
             'FROM crczp.events.trainings.*',
@@ -491,7 +491,7 @@ describe('GROUP BY and HAVING', () => {
                 )
                 .groupBy(dateFormat(field('timestamp'), lit('%Y-%m')))
                 .orderBy(dateFormat(field('timestamp'), lit('%Y-%m')), 'ASC')
-                .toSQL(),
+                .build(),
         ).toBe(L(
             `SELECT DATE_FORMAT(timestamp, '%Y-%m') AS month, COUNT(*) AS cnt`,
             'FROM crczp.events.trainings.*',
@@ -514,7 +514,7 @@ describe('GROUP BY and HAVING', () => {
                 )
                 .orderBy(dateFormat(field('timestamp'), lit('%Y-%m')), 'ASC')
                 .orderBy(field('type'), 'ASC')
-                .toSQL(),
+                .build(),
         ).toBe(L(
             `SELECT DATE_FORMAT(timestamp, '%Y-%m') AS month, type, COUNT(*) AS cnt`,
             'FROM crczp.events.trainings.*',
@@ -534,7 +534,7 @@ describe('GROUP BY and HAVING', () => {
                 .groupBy(field('user_ref_id'))
                 .having(gte('hint_count' as any, 2))
                 .orderBy(field('hint_count' as any), 'DESC')
-                .toSQL(),
+                .build(),
         ).toBe(L(
             'SELECT user_ref_id, COUNT(*) AS hint_count',
             'FROM crczp.events.trainings.*',
@@ -551,7 +551,7 @@ describe('GROUP BY and HAVING', () => {
                 .select(field('training_run_id'), field('level'), as(count('*'), 'cnt'))
                 .groupBy(field('training_run_id'))
                 .addGroupBy(field('level'))
-                .toSQL(),
+                .build(),
         ).toBe(L(
             'SELECT training_run_id, level, COUNT(*) AS cnt',
             'FROM crczp.events.trainings.*',
@@ -570,7 +570,7 @@ describe('GROUP BY and HAVING', () => {
                 .groupBy(field('training_run_id'))
                 .having(gt('cnt' as any, 5))
                 .andHaving(gte('avg_score' as any, 40))
-                .toSQL(),
+                .build(),
         ).toBe(L(
             'SELECT training_run_id, COUNT(*) AS cnt, AVG(actual_score_in_level) AS avg_score',
             'FROM crczp.events.trainings.*',
@@ -589,7 +589,7 @@ describe('ORDER BY', () => {
                 .select(field('training_run_id'), field('timestamp'))
                 .where(eq('type', EventType.TrainingRunStarted))
                 .orderBy(field('timestamp'), 'DESC')
-                .toSQL(),
+                .build(),
         ).toBe(L(
             'SELECT training_run_id, timestamp',
             'FROM crczp.events.trainings.*',
@@ -605,7 +605,7 @@ describe('ORDER BY', () => {
                 .orderBy(field('training_run_id'), 'ASC')
                 .orderBy(field('level'), 'ASC')
                 .orderBy(field('actual_score_in_level'), 'DESC')
-                .toSQL(),
+                .build(),
         ).toBe(L(
             'SELECT training_run_id, level, actual_score_in_level',
             'FROM crczp.events.trainings.*',
@@ -618,7 +618,7 @@ describe('ORDER BY', () => {
             new QueryBuilder('crczp.events.trainings.*')
                 .select(field('user_ref_id'), field('hint_title'))
                 .orderBy(field('hint_title'), 'ASC', 'FIRST')
-                .toSQL(),
+                .build(),
         ).toBe(L(
             'SELECT user_ref_id, hint_title',
             'FROM crczp.events.trainings.*',
@@ -631,7 +631,7 @@ describe('ORDER BY', () => {
             new QueryBuilder('crczp.events.trainings.*')
                 .select(field('user_ref_id'), field('hint_title'))
                 .orderBy(field('hint_title'), 'DESC', 'LAST')
-                .toSQL(),
+                .build(),
         ).toBe(L(
             'SELECT user_ref_id, hint_title',
             'FROM crczp.events.trainings.*',
@@ -646,7 +646,7 @@ describe('ORDER BY', () => {
                 .groupBy(field('training_run_id'))
                 .orderBy(count('*'), 'DESC')
                 .limit(10)
-                .toSQL(),
+                .build(),
         ).toBe(L(
             'SELECT training_run_id, COUNT(*) AS cnt',
             'FROM crczp.events.trainings.*',
@@ -665,7 +665,7 @@ describe('ORDER BY', () => {
                 )
                 .where(eq('type', EventType.TrainingRunEnded))
                 .orderBy(sub(field('end_time'), field('start_time')), 'ASC')
-                .toSQL(),
+                .build(),
         ).toBe(L(
             'SELECT training_run_id, (end_time - start_time) AS duration',
             'FROM crczp.events.trainings.*',
@@ -685,7 +685,7 @@ describe('LIMIT and OFFSET', () => {
                 .where(eq('training_run_id', 1))
                 .orderBy(field('timestamp'), 'ASC')
                 .limit(100)
-                .toSQL(),
+                .build(),
         ).toBe(L(
             'SELECT *',
             'FROM crczp.events.trainings.*',
@@ -702,7 +702,7 @@ describe('LIMIT and OFFSET', () => {
                 .orderBy(field('timestamp'), 'ASC')
                 .limit(20)
                 .offset(40)
-                .toSQL(),
+                .build(),
         ).toBe(L(
             'SELECT *',
             'FROM crczp.events.trainings.*',
@@ -723,7 +723,7 @@ describe('expressions in SELECT', () => {
                     as(mul(div(field('actual_score_in_level'), field('max_score')), lit(100)), 'pct'),
                 )
                 .where(eq('type', EventType.LevelCompleted))
-                .toSQL(),
+                .build(),
         ).toBe(L(
             'SELECT training_run_id, ((actual_score_in_level / max_score) * 100) AS pct',
             'FROM crczp.events.trainings.*',
@@ -739,7 +739,7 @@ describe('expressions in SELECT', () => {
                     as(cast(field('timestamp'), 'DATETIME'), 'event_time'),
                 )
                 .where(eq('training_run_id', 5))
-                .toSQL(),
+                .build(),
         ).toBe(L(
             'SELECT training_run_id, CAST(timestamp AS DATETIME) AS event_time',
             'FROM crczp.events.trainings.*',
@@ -756,7 +756,7 @@ describe('expressions in SELECT', () => {
                 )
                 .where(eq('type', EventType.LevelStarted))
                 .groupBy(field('training_run_id'))
-                .toSQL(),
+                .build(),
         ).toBe(L(
             'SELECT training_run_id, COUNT(DISTINCT user_ref_id) AS unique_users',
             'FROM crczp.events.trainings.*',
@@ -777,7 +777,7 @@ describe('expressions in SELECT', () => {
                 )
                 .where(eq('type', EventType.LevelCompleted))
                 .groupBy(field('training_run_id'))
-                .toSQL(),
+                .build(),
         ).toBe(L(
             'SELECT training_run_id, SUM(actual_score_in_level) AS total_score, ROUND(AVG(actual_score_in_level), 2) AS avg_score, MIN(actual_score_in_level) AS min_score, MAX(actual_score_in_level) AS max_score',
             'FROM crczp.events.trainings.*',
@@ -796,7 +796,7 @@ describe('expressions in SELECT', () => {
                 )
                 .where(eq('type', EventType.HintTaken))
                 .orderBy(field('timestamp'), 'ASC')
-                .toSQL(),
+                .build(),
         ).toBe(L(
             `SELECT training_run_id, IFNULL(hint_title, '(no title)') AS hint_label, hint_penalty_points`,
             'FROM crczp.events.trainings.*',
@@ -815,7 +815,7 @@ describe('JOINs', () => {
                 .select('*')
                 .join('crczp.runs', 'r', [{ left: 'e.training_run_id', right: 'r.id' }])
                 .where(eq('training_run_id', 42))
-                .toSQL(),
+                .build(),
         ).toBe(L(
             'SELECT *',
             'FROM crczp.events.trainings.* e',
@@ -829,7 +829,7 @@ describe('JOINs', () => {
             new QueryBuilder('crczp.events.trainings.*', 'e')
                 .select('*')
                 .leftJoin('crczp.runs', 'r', [{ left: 'e.training_run_id', right: 'r.id' }])
-                .toSQL(),
+                .build(),
         ).toBe(L(
             'SELECT *',
             'FROM crczp.events.trainings.* e',
@@ -842,7 +842,7 @@ describe('JOINs', () => {
             new QueryBuilder('crczp.events.trainings.*', 'e')
                 .select('*')
                 .crossJoin('crczp.meta', 'm')
-                .toSQL(),
+                .build(),
         ).toBe(L(
             'SELECT *',
             'FROM crczp.events.trainings.* e',
@@ -861,7 +861,7 @@ describe('clone()', () => {
             .groupBy(field('training_run_id'))
             .limit(50);
 
-        expect(base.clone().toSQL()).toBe(base.toSQL());
+        expect(base.clone().build()).toBe(base.build());
     });
 
     it('modifying a clone does not affect the original', () => {
@@ -874,14 +874,14 @@ describe('clone()', () => {
             .andWhere(gt('actual_score_in_level', 50))
             .limit(5);
 
-        expect(base.toSQL()).toBe(L(
+        expect(base.build()).toBe(L(
             'SELECT training_run_id',
             'FROM crczp.events.trainings.*',
             `WHERE type = 'cz.cyberrange.platform.events.trainings.LevelStarted'`,
             'LIMIT 10',
         ));
 
-        expect(fork.toSQL()).toBe(L(
+        expect(fork.build()).toBe(L(
             'SELECT training_run_id',
             'FROM crczp.events.trainings.*',
             `WHERE (type = 'cz.cyberrange.platform.events.trainings.LevelStarted' AND actual_score_in_level > 50)`,
@@ -908,7 +908,7 @@ describe('realistic analytics queries', () => {
                 .groupBy(field('training_run_id'))
                 .orderBy(sum(field('actual_score_in_level')), 'DESC')
                 .limit(10)
-                .toSQL(),
+                .build(),
         ).toBe(L(
             'SELECT training_run_id, SUM(actual_score_in_level) AS total_score, COUNT(*) AS levels_completed',
             'FROM crczp.events.trainings.*',
@@ -935,7 +935,7 @@ describe('realistic analytics queries', () => {
                 .groupBy(field('training_run_id'), field('user_ref_id'))
                 .having(gt('hint_count' as any, 3))
                 .orderBy(field('total_penalty' as any), 'DESC')
-                .toSQL(),
+                .build(),
         ).toBe(L(
             'SELECT training_run_id, user_ref_id, COUNT(*) AS hint_count, SUM(hint_penalty_points) AS total_penalty',
             'FROM crczp.events.trainings.*',
@@ -961,7 +961,7 @@ describe('realistic analytics queries', () => {
                     eq('training_instance_id', 5),
                 ))
                 .orderBy(field('user_ref_id'), 'ASC')
-                .toSQL(),
+                .build(),
         ).toBe(L(
             'SELECT DISTINCT user_ref_id',
             'FROM crczp.events.trainings.*',
@@ -985,7 +985,7 @@ describe('realistic analytics queries', () => {
                     isNotNull('end_time'),
                 ))
                 .orderBy(sub(field('end_time'), field('start_time')), 'ASC')
-                .toSQL(),
+                .build(),
         ).toBe(L(
             'SELECT training_run_id, start_time, end_time, (end_time - start_time) AS duration_ms',
             'FROM crczp.events.trainings.*',
@@ -1010,7 +1010,7 @@ describe('realistic analytics queries', () => {
                 .groupBy(field('user_ref_id'), field('level'))
                 .orderBy(field('level'), 'ASC')
                 .orderBy(max(field('total_assessment_level_score')), 'DESC')
-                .toSQL(),
+                .build(),
         ).toBe(L(
             'SELECT user_ref_id, level, MAX(total_assessment_level_score) AS best_score',
             'FROM crczp.events.trainings.*',
@@ -1031,7 +1031,7 @@ describe('realistic analytics queries', () => {
                 ))
                 .orderBy(field('timestamp'), 'DESC')
                 .limit(50)
-                .toSQL(),
+                .build(),
         ).toBe(L(
             'SELECT training_run_id, user_ref_id, answer_content',
             'FROM crczp.events.trainings.*',
@@ -1052,7 +1052,7 @@ describe('realistic analytics queries', () => {
                 .orderBy(field('timestamp'), 'DESC')
                 .limit(25)
                 .offset(75)
-                .toSQL(),
+                .build(),
         ).toBe(L(
             'SELECT timestamp, type, training_run_id, user_ref_id',
             'FROM crczp.events.trainings.*',
@@ -1079,7 +1079,7 @@ describe('realistic analytics queries', () => {
                 ))
                 .orderBy(field('training_run_id'), 'ASC')
                 .orderBy(field('level'), 'ASC')
-                .toSQL(),
+                .build(),
         ).toBe(L(
             `SELECT training_run_id, level, level_type, TIMESTAMPDIFF('SECOND', start_time, end_time) AS seconds`,
             'FROM crczp.events.trainings.*',

--- a/libs/api/opensearch-query-builder/src/tests/queries.spec.ts
+++ b/libs/api/opensearch-query-builder/src/tests/queries.spec.ts
@@ -1,0 +1,1090 @@
+/**
+ * Full-query tests for the OpenSearch SQL query builder.
+ *
+ * Every assertion checks the complete toSQL() output. This intentionally
+ * covers SELECT, WHERE, GROUP BY, HAVING, ORDER BY, LIMIT, JOINs, and
+ * combinations thereof — catching serialisation bugs that narrow unit tests
+ * would miss.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { QueryBuilder } from '../lib/query-builder';
+import {
+    and,
+    between,
+    eq,
+    gt,
+    gte,
+    inList,
+    isNotNull,
+    isNull,
+    like,
+    lt,
+    matchQuery,
+    multiMatch,
+    neq,
+    not,
+    notIn,
+    notLike,
+    or,
+    score,
+    wildcardQuery
+} from '../lib/predicates';
+import {
+    as,
+    avg,
+    cast,
+    count,
+    dateFormat,
+    div,
+    field,
+    fn,
+    lit,
+    max,
+    min,
+    mul,
+    round,
+    sub,
+    sum
+} from '../lib/expressions';
+import { EventType } from '../lib/schema';
+
+/** Join SQL lines into a single string (mirrors toSQL() clause separator). */
+const L = (...lines: string[]) => lines.join('\n');
+
+// ─── Basic SELECT shapes ───────────────────────────────────────────────────────
+
+describe('SELECT shapes', () => {
+    it('defaults to SELECT * with no select() call', () => {
+        expect(new QueryBuilder('crczp.events.trainings.*').toSQL()).toBe(L(
+            'SELECT *',
+            'FROM crczp.events.trainings.*',
+        ));
+    });
+
+    it('SELECT specific fields', () => {
+        expect(
+            new QueryBuilder('crczp.events.trainings.*')
+                .select(field('training_run_id'), field('type'), field('timestamp'))
+                .toSQL(),
+        ).toBe(L(
+            'SELECT training_run_id, type, timestamp',
+            'FROM crczp.events.trainings.*',
+        ));
+    });
+
+    it('SELECT with aggregate alias', () => {
+        expect(
+            new QueryBuilder('crczp.events.trainings.*')
+                .select(field('training_run_id'), as(count('*'), 'cnt'))
+                .toSQL(),
+        ).toBe(L(
+            'SELECT training_run_id, COUNT(*) AS cnt',
+            'FROM crczp.events.trainings.*',
+        ));
+    });
+
+    it('SELECT DISTINCT single column', () => {
+        expect(
+            new QueryBuilder('crczp.events.trainings.*')
+                .select(field('user_ref_id'))
+                .distinct()
+                .toSQL(),
+        ).toBe(L(
+            'SELECT DISTINCT user_ref_id',
+            'FROM crczp.events.trainings.*',
+        ));
+    });
+
+    it('addSelect appends columns and strips leading *', () => {
+        expect(
+            new QueryBuilder('crczp.events.trainings.*')
+                .addSelect(field('type'))
+                .addSelect(field('timestamp'))
+                .toSQL(),
+        ).toBe(L(
+            'SELECT type, timestamp',
+            'FROM crczp.events.trainings.*',
+        ));
+    });
+
+    it('selectAll() resets back to SELECT *', () => {
+        expect(
+            new QueryBuilder('crczp.events.trainings.*')
+                .select(field('type'))
+                .selectAll()
+                .toSQL(),
+        ).toBe(L(
+            'SELECT *',
+            'FROM crczp.events.trainings.*',
+        ));
+    });
+
+    it('FROM with index alias', () => {
+        expect(
+            new QueryBuilder('crczp.events.trainings.*', 'e')
+                .select(field('type'), field('timestamp'))
+                .toSQL(),
+        ).toBe(L(
+            'SELECT type, timestamp',
+            'FROM crczp.events.trainings.* e',
+        ));
+    });
+});
+
+// ─── WHERE conditions ─────────────────────────────────────────────────────────
+
+describe('WHERE conditions', () => {
+    it('equality on number field', () => {
+        expect(
+            new QueryBuilder('crczp.events.trainings.*')
+                .select(field('type'), field('level'))
+                .where(eq('training_run_id', 42))
+                .toSQL(),
+        ).toBe(L(
+            'SELECT type, level',
+            'FROM crczp.events.trainings.*',
+            'WHERE training_run_id = 42',
+        ));
+    });
+
+    it('equality on EventType constant', () => {
+        expect(
+            new QueryBuilder('crczp.events.trainings.*')
+                .select('*')
+                .where(eq('type', EventType.LevelStarted))
+                .toSQL(),
+        ).toBe(L(
+            'SELECT *',
+            'FROM crczp.events.trainings.*',
+            `WHERE type = 'cz.cyberrange.platform.events.trainings.LevelStarted'`,
+        ));
+    });
+
+    it('not equal on string field', () => {
+        expect(
+            new QueryBuilder('crczp.events.trainings.*')
+                .select(field('training_run_id'), field('type'))
+                .where(neq('type', EventType.AssessmentAnswers))
+                .toSQL(),
+        ).toBe(L(
+            'SELECT training_run_id, type',
+            'FROM crczp.events.trainings.*',
+            `WHERE type <> 'cz.cyberrange.platform.events.trainings.AssessmentAnswers'`,
+        ));
+    });
+
+    it('BETWEEN on timestamp range', () => {
+        expect(
+            new QueryBuilder('crczp.events.trainings.*')
+                .select(field('type'), field('timestamp'))
+                .where(between('timestamp', 1700000000000, 1800000000000))
+                .toSQL(),
+        ).toBe(L(
+            'SELECT type, timestamp',
+            'FROM crczp.events.trainings.*',
+            'WHERE timestamp BETWEEN 1700000000000 AND 1800000000000',
+        ));
+    });
+
+    it('IN list of EventType values', () => {
+        expect(
+            new QueryBuilder('crczp.events.trainings.*')
+                .select(field('type'), field('training_run_id'), field('actual_score_in_level'))
+                .where(inList('type', [EventType.LevelStarted, EventType.LevelCompleted]))
+                .toSQL(),
+        ).toBe(L(
+            'SELECT type, training_run_id, actual_score_in_level',
+            'FROM crczp.events.trainings.*',
+            `WHERE type IN ('cz.cyberrange.platform.events.trainings.LevelStarted', 'cz.cyberrange.platform.events.trainings.LevelCompleted')`,
+        ));
+    });
+
+    it('NOT IN on level_order', () => {
+        expect(
+            new QueryBuilder('crczp.events.trainings.*')
+                .select('*')
+                .where(notIn('level_order', [0, 9, 10]))
+                .toSQL(),
+        ).toBe(L(
+            'SELECT *',
+            'FROM crczp.events.trainings.*',
+            'WHERE level_order NOT IN (0, 9, 10)',
+        ));
+    });
+
+    it('IS NULL on optional field', () => {
+        expect(
+            new QueryBuilder('crczp.events.trainings.*')
+                .select(field('training_run_id'), field('hint_title'))
+                .where(isNull('hint_title'))
+                .toSQL(),
+        ).toBe(L(
+            'SELECT training_run_id, hint_title',
+            'FROM crczp.events.trainings.*',
+            'WHERE hint_title IS NULL',
+        ));
+    });
+
+    it('IS NOT NULL on level_title', () => {
+        expect(
+            new QueryBuilder('crczp.events.trainings.*')
+                .select('*')
+                .where(isNotNull('level_title'))
+                .toSQL(),
+        ).toBe(L(
+            'SELECT *',
+            'FROM crczp.events.trainings.*',
+            'WHERE level_title IS NOT NULL',
+        ));
+    });
+
+    it('LIKE prefix pattern', () => {
+        expect(
+            new QueryBuilder('crczp.events.trainings.*')
+                .select(field('training_run_id'), field('type'))
+                .where(like('type', 'cz.cyberrange.platform.events.trainings.%'))
+                .toSQL(),
+        ).toBe(L(
+            'SELECT training_run_id, type',
+            'FROM crczp.events.trainings.*',
+            `WHERE type LIKE 'cz.cyberrange.platform.events.trainings.%'`,
+        ));
+    });
+
+    it('NOT LIKE filter', () => {
+        expect(
+            new QueryBuilder('crczp.events.trainings.*')
+                .select('*')
+                .where(notLike('level_title', 'Draft%'))
+                .toSQL(),
+        ).toBe(L(
+            'SELECT *',
+            'FROM crczp.events.trainings.*',
+            `WHERE level_title NOT LIKE 'Draft%'`,
+        ));
+    });
+
+    it('MATCH_QUERY with analyzer and boost', () => {
+        expect(
+            new QueryBuilder('crczp.events.trainings.*')
+                .select('*')
+                .where(matchQuery('level_title', 'network security', { analyzer: 'standard', boost: 1.5 }))
+                .toSQL(),
+        ).toBe(L(
+            'SELECT *',
+            'FROM crczp.events.trainings.*',
+            `WHERE MATCH_QUERY(level_title, 'network security', analyzer='standard', boost=1.5)`,
+        ));
+    });
+
+    it('MULTI_MATCH across fields with AND operator', () => {
+        expect(
+            new QueryBuilder('crczp.events.trainings.*')
+                .select(field('training_run_id'), field('type'))
+                .where(multiMatch(['type', 'level_title'], 'security', { operator: 'AND' }))
+                .toSQL(),
+        ).toBe(L(
+            'SELECT training_run_id, type',
+            'FROM crczp.events.trainings.*',
+            `WHERE MULTI_MATCH('query'='security', 'fields'='type,level_title', operator='AND')`,
+        ));
+    });
+
+    it('WILDCARD_QUERY with boost', () => {
+        expect(
+            new QueryBuilder('crczp.events.trainings.*')
+                .select('*')
+                .where(wildcardQuery('type', 'cz.cyberrange.*', 2))
+                .toSQL(),
+        ).toBe(L(
+            'SELECT *',
+            'FROM crczp.events.trainings.*',
+            `WHERE WILDCARD_QUERY(type, 'cz.cyberrange.*', boost=2)`,
+        ));
+    });
+
+    it('SCORE wrapping MATCH_QUERY', () => {
+        expect(
+            new QueryBuilder('crczp.events.trainings.*')
+                .select(field('training_run_id'), field('level_title'))
+                .where(score(matchQuery('level_title', 'firewall'), 1.2))
+                .toSQL(),
+        ).toBe(L(
+            'SELECT training_run_id, level_title',
+            'FROM crczp.events.trainings.*',
+            `WHERE SCORE(MATCH_QUERY(level_title, 'firewall'), 1.2)`,
+        ));
+    });
+
+    it('compound AND — run id + event type', () => {
+        expect(
+            new QueryBuilder('crczp.events.trainings.*')
+                .select(field('type'), field('level'), field('actual_score_in_level'))
+                .where(and(
+                    eq('training_run_id', 7),
+                    eq('type', EventType.LevelCompleted),
+                ))
+                .toSQL(),
+        ).toBe(L(
+            'SELECT type, level, actual_score_in_level',
+            'FROM crczp.events.trainings.*',
+            `WHERE (training_run_id = 7 AND type = 'cz.cyberrange.platform.events.trainings.LevelCompleted')`,
+        ));
+    });
+
+    it('compound OR — two event types', () => {
+        expect(
+            new QueryBuilder('crczp.events.trainings.*')
+                .select(field('training_run_id'), field('type'), field('timestamp'))
+                .where(or(
+                    eq('type', EventType.CorrectAnswerSubmitted),
+                    eq('type', EventType.WrongAnswerSubmitted),
+                ))
+                .toSQL(),
+        ).toBe(L(
+            'SELECT training_run_id, type, timestamp',
+            'FROM crczp.events.trainings.*',
+            `WHERE (type = 'cz.cyberrange.platform.events.trainings.CorrectAnswerSubmitted' OR type = 'cz.cyberrange.platform.events.trainings.WrongAnswerSubmitted')`,
+        ));
+    });
+
+    it('NOT wrapping a predicate', () => {
+        expect(
+            new QueryBuilder('crczp.events.trainings.*')
+                .select('*')
+                .where(not(eq('level_type', 'ASSESSMENT')))
+                .toSQL(),
+        ).toBe(L(
+            'SELECT *',
+            'FROM crczp.events.trainings.*',
+            `WHERE NOT (level_type = 'ASSESSMENT')`,
+        ));
+    });
+
+    it('nested AND/OR — run filter AND (high score OR hint taken)', () => {
+        expect(
+            new QueryBuilder('crczp.events.trainings.*')
+                .select(field('training_run_id'), field('type'), field('actual_score_in_level'))
+                .where(and(
+                    eq('training_run_id', 15),
+                    or(
+                        gt('actual_score_in_level', 80),
+                        eq('type', EventType.HintTaken),
+                    ),
+                ))
+                .toSQL(),
+        ).toBe(L(
+            'SELECT training_run_id, type, actual_score_in_level',
+            'FROM crczp.events.trainings.*',
+            `WHERE (training_run_id = 15 AND (actual_score_in_level > 80 OR type = 'cz.cyberrange.platform.events.trainings.HintTaken'))`,
+        ));
+    });
+
+    it('andWhere() flattens repeated calls into one flat AND', () => {
+        expect(
+            new QueryBuilder('crczp.events.trainings.*')
+                .select(field('type'), field('level'))
+                .where(eq('training_run_id', 3))
+                .andWhere(eq('type', EventType.LevelCompleted))
+                .andWhere(gte('actual_score_in_level', 50))
+                .toSQL(),
+        ).toBe(L(
+            'SELECT type, level',
+            'FROM crczp.events.trainings.*',
+            `WHERE (training_run_id = 3 AND type = 'cz.cyberrange.platform.events.trainings.LevelCompleted' AND actual_score_in_level >= 50)`,
+        ));
+    });
+
+    it('orWhere() flattens repeated calls into one flat OR', () => {
+        expect(
+            new QueryBuilder('crczp.events.trainings.*')
+                .select('*')
+                .where(eq('type', EventType.HintTaken))
+                .orWhere(eq('type', EventType.SolutionDisplayed))
+                .orWhere(eq('type', EventType.WrongAnswerSubmitted))
+                .toSQL(),
+        ).toBe(L(
+            'SELECT *',
+            'FROM crczp.events.trainings.*',
+            `WHERE (type = 'cz.cyberrange.platform.events.trainings.HintTaken' OR type = 'cz.cyberrange.platform.events.trainings.SolutionDisplayed' OR type = 'cz.cyberrange.platform.events.trainings.WrongAnswerSubmitted')`,
+        ));
+    });
+});
+
+// ─── Special character field names ────────────────────────────────────────────
+
+describe('field name quoting', () => {
+
+    it("string literal with embedded single quote is escaped", () => {
+        expect(
+            new QueryBuilder('crczp.events.trainings.*')
+                .select('*')
+                .where(eq('level_title', "Attacker's Toolkit"))
+                .toSQL(),
+        ).toBe(L(
+            'SELECT *',
+            'FROM crczp.events.trainings.*',
+            `WHERE level_title = 'Attacker''s Toolkit'`,
+        ));
+    });
+
+    it('LIKE pattern with embedded single quote is escaped', () => {
+        expect(
+            new QueryBuilder('crczp.events.trainings.*')
+                .select('*')
+                .where(like('level_title', "it's%"))
+                .toSQL(),
+        ).toBe(L(
+            'SELECT *',
+            'FROM crczp.events.trainings.*',
+            `WHERE level_title LIKE 'it''s%'`,
+        ));
+    });
+});
+
+// ─── GROUP BY and HAVING ──────────────────────────────────────────────────────
+
+describe('GROUP BY and HAVING', () => {
+    it('event count per training run', () => {
+        expect(
+            new QueryBuilder('crczp.events.trainings.*')
+                .select(field('training_run_id'), as(count('*'), 'event_count'))
+                .where(eq('type', EventType.LevelCompleted))
+                .groupBy(field('training_run_id'))
+                .orderBy(field('training_run_id'), 'ASC')
+                .toSQL(),
+        ).toBe(L(
+            'SELECT training_run_id, COUNT(*) AS event_count',
+            'FROM crczp.events.trainings.*',
+            `WHERE type = 'cz.cyberrange.platform.events.trainings.LevelCompleted'`,
+            'GROUP BY training_run_id',
+            'ORDER BY training_run_id ASC',
+        ));
+    });
+
+    it('average score per level with HAVING threshold', () => {
+        expect(
+            new QueryBuilder('crczp.events.trainings.*')
+                .select(field('level'), as(avg(field('actual_score_in_level')), 'avg_score'))
+                .where(eq('type', EventType.LevelCompleted))
+                .groupBy(field('level'))
+                .having(gt('avg_score' as any, 60))
+                .orderBy(field('level'), 'ASC')
+                .toSQL(),
+        ).toBe(L(
+            'SELECT level, AVG(actual_score_in_level) AS avg_score',
+            'FROM crczp.events.trainings.*',
+            `WHERE type = 'cz.cyberrange.platform.events.trainings.LevelCompleted'`,
+            'GROUP BY level',
+            'HAVING avg_score > 60',
+            'ORDER BY level ASC',
+        ));
+    });
+
+    it('events bucketed by month using DATE_FORMAT', () => {
+        expect(
+            new QueryBuilder('crczp.events.trainings.*')
+                .select(
+                    as(dateFormat(field('timestamp'), lit('%Y-%m')), 'month'),
+                    as(count('*'), 'cnt'),
+                )
+                .groupBy(dateFormat(field('timestamp'), lit('%Y-%m')))
+                .orderBy(dateFormat(field('timestamp'), lit('%Y-%m')), 'ASC')
+                .toSQL(),
+        ).toBe(L(
+            `SELECT DATE_FORMAT(timestamp, '%Y-%m') AS month, COUNT(*) AS cnt`,
+            'FROM crczp.events.trainings.*',
+            `GROUP BY DATE_FORMAT(timestamp, '%Y-%m')`,
+            `ORDER BY DATE_FORMAT(timestamp, '%Y-%m') ASC`,
+        ));
+    });
+
+    it('event count per type per month', () => {
+        expect(
+            new QueryBuilder('crczp.events.trainings.*')
+                .select(
+                    as(dateFormat(field('timestamp'), lit('%Y-%m')), 'month'),
+                    field('type'),
+                    as(count('*'), 'cnt'),
+                )
+                .groupBy(
+                    dateFormat(field('timestamp'), lit('%Y-%m')),
+                    field('type'),
+                )
+                .orderBy(dateFormat(field('timestamp'), lit('%Y-%m')), 'ASC')
+                .orderBy(field('type'), 'ASC')
+                .toSQL(),
+        ).toBe(L(
+            `SELECT DATE_FORMAT(timestamp, '%Y-%m') AS month, type, COUNT(*) AS cnt`,
+            'FROM crczp.events.trainings.*',
+            `GROUP BY DATE_FORMAT(timestamp, '%Y-%m'), type`,
+            `ORDER BY DATE_FORMAT(timestamp, '%Y-%m') ASC, type ASC`,
+        ));
+    });
+
+    it('hint count per user with HAVING requiring at least 2', () => {
+        expect(
+            new QueryBuilder('crczp.events.trainings.*')
+                .select(field('user_ref_id'), as(count('*'), 'hint_count'))
+                .where(and(
+                    eq('training_run_id', 10),
+                    eq('type', EventType.HintTaken),
+                ))
+                .groupBy(field('user_ref_id'))
+                .having(gte('hint_count' as any, 2))
+                .orderBy(field('hint_count' as any), 'DESC')
+                .toSQL(),
+        ).toBe(L(
+            'SELECT user_ref_id, COUNT(*) AS hint_count',
+            'FROM crczp.events.trainings.*',
+            `WHERE (training_run_id = 10 AND type = 'cz.cyberrange.platform.events.trainings.HintTaken')`,
+            'GROUP BY user_ref_id',
+            'HAVING hint_count >= 2',
+            'ORDER BY hint_count DESC',
+        ));
+    });
+
+    it('addGroupBy appends to existing GROUP BY', () => {
+        expect(
+            new QueryBuilder('crczp.events.trainings.*')
+                .select(field('training_run_id'), field('level'), as(count('*'), 'cnt'))
+                .groupBy(field('training_run_id'))
+                .addGroupBy(field('level'))
+                .toSQL(),
+        ).toBe(L(
+            'SELECT training_run_id, level, COUNT(*) AS cnt',
+            'FROM crczp.events.trainings.*',
+            'GROUP BY training_run_id, level',
+        ));
+    });
+
+    it('andHaving() flattens multiple HAVING conditions', () => {
+        expect(
+            new QueryBuilder('crczp.events.trainings.*')
+                .select(
+                    field('training_run_id'),
+                    as(count('*'), 'cnt'),
+                    as(avg(field('actual_score_in_level')), 'avg_score'),
+                )
+                .groupBy(field('training_run_id'))
+                .having(gt('cnt' as any, 5))
+                .andHaving(gte('avg_score' as any, 40))
+                .toSQL(),
+        ).toBe(L(
+            'SELECT training_run_id, COUNT(*) AS cnt, AVG(actual_score_in_level) AS avg_score',
+            'FROM crczp.events.trainings.*',
+            'GROUP BY training_run_id',
+            'HAVING (cnt > 5 AND avg_score >= 40)',
+        ));
+    });
+});
+
+// ─── ORDER BY ────────────────────────────────────────────────────────────────
+
+describe('ORDER BY', () => {
+    it('single column DESC', () => {
+        expect(
+            new QueryBuilder('crczp.events.trainings.*')
+                .select(field('training_run_id'), field('timestamp'))
+                .where(eq('type', EventType.TrainingRunStarted))
+                .orderBy(field('timestamp'), 'DESC')
+                .toSQL(),
+        ).toBe(L(
+            'SELECT training_run_id, timestamp',
+            'FROM crczp.events.trainings.*',
+            `WHERE type = 'cz.cyberrange.platform.events.trainings.TrainingRunStarted'`,
+            'ORDER BY timestamp DESC',
+        ));
+    });
+
+    it('multiple ORDER BY columns', () => {
+        expect(
+            new QueryBuilder('crczp.events.trainings.*')
+                .select(field('training_run_id'), field('level'), field('actual_score_in_level'))
+                .orderBy(field('training_run_id'), 'ASC')
+                .orderBy(field('level'), 'ASC')
+                .orderBy(field('actual_score_in_level'), 'DESC')
+                .toSQL(),
+        ).toBe(L(
+            'SELECT training_run_id, level, actual_score_in_level',
+            'FROM crczp.events.trainings.*',
+            'ORDER BY training_run_id ASC, level ASC, actual_score_in_level DESC',
+        ));
+    });
+
+    it('NULLS FIRST: emits IS NOT NULL before direction', () => {
+        expect(
+            new QueryBuilder('crczp.events.trainings.*')
+                .select(field('user_ref_id'), field('hint_title'))
+                .orderBy(field('hint_title'), 'ASC', 'FIRST')
+                .toSQL(),
+        ).toBe(L(
+            'SELECT user_ref_id, hint_title',
+            'FROM crczp.events.trainings.*',
+            'ORDER BY hint_title IS NOT NULL ASC',
+        ));
+    });
+
+    it('NULLS LAST: emits IS NULL before direction', () => {
+        expect(
+            new QueryBuilder('crczp.events.trainings.*')
+                .select(field('user_ref_id'), field('hint_title'))
+                .orderBy(field('hint_title'), 'DESC', 'LAST')
+                .toSQL(),
+        ).toBe(L(
+            'SELECT user_ref_id, hint_title',
+            'FROM crczp.events.trainings.*',
+            'ORDER BY hint_title IS NULL DESC',
+        ));
+    });
+
+    it('ORDER BY aggregate', () => {
+        expect(
+            new QueryBuilder('crczp.events.trainings.*')
+                .select(field('training_run_id'), as(count('*'), 'cnt'))
+                .groupBy(field('training_run_id'))
+                .orderBy(count('*'), 'DESC')
+                .limit(10)
+                .toSQL(),
+        ).toBe(L(
+            'SELECT training_run_id, COUNT(*) AS cnt',
+            'FROM crczp.events.trainings.*',
+            'GROUP BY training_run_id',
+            'ORDER BY COUNT(*) DESC',
+            'LIMIT 10',
+        ));
+    });
+
+    it('ORDER BY arithmetic expression', () => {
+        expect(
+            new QueryBuilder('crczp.events.trainings.*')
+                .select(
+                    field('training_run_id'),
+                    as(sub(field('end_time'), field('start_time')), 'duration'),
+                )
+                .where(eq('type', EventType.TrainingRunEnded))
+                .orderBy(sub(field('end_time'), field('start_time')), 'ASC')
+                .toSQL(),
+        ).toBe(L(
+            'SELECT training_run_id, (end_time - start_time) AS duration',
+            'FROM crczp.events.trainings.*',
+            `WHERE type = 'cz.cyberrange.platform.events.trainings.TrainingRunEnded'`,
+            'ORDER BY (end_time - start_time) ASC',
+        ));
+    });
+});
+
+// ─── LIMIT and OFFSET ─────────────────────────────────────────────────────────
+
+describe('LIMIT and OFFSET', () => {
+    it('LIMIT only', () => {
+        expect(
+            new QueryBuilder('crczp.events.trainings.*')
+                .select('*')
+                .where(eq('training_run_id', 1))
+                .orderBy(field('timestamp'), 'ASC')
+                .limit(100)
+                .toSQL(),
+        ).toBe(L(
+            'SELECT *',
+            'FROM crczp.events.trainings.*',
+            'WHERE training_run_id = 1',
+            'ORDER BY timestamp ASC',
+            'LIMIT 100',
+        ));
+    });
+
+    it('LIMIT with OFFSET uses MySQL-style LIMIT offset, size syntax', () => {
+        expect(
+            new QueryBuilder('crczp.events.trainings.*')
+                .select('*')
+                .orderBy(field('timestamp'), 'ASC')
+                .limit(20)
+                .offset(40)
+                .toSQL(),
+        ).toBe(L(
+            'SELECT *',
+            'FROM crczp.events.trainings.*',
+            'ORDER BY timestamp ASC',
+            'LIMIT 40, 20',
+        ));
+    });
+});
+
+// ─── Expressions in SELECT ────────────────────────────────────────────────────
+
+describe('expressions in SELECT', () => {
+    it('arithmetic: percentage score', () => {
+        expect(
+            new QueryBuilder('crczp.events.trainings.*')
+                .select(
+                    field('training_run_id'),
+                    as(mul(div(field('actual_score_in_level'), field('max_score')), lit(100)), 'pct'),
+                )
+                .where(eq('type', EventType.LevelCompleted))
+                .toSQL(),
+        ).toBe(L(
+            'SELECT training_run_id, ((actual_score_in_level / max_score) * 100) AS pct',
+            'FROM crczp.events.trainings.*',
+            `WHERE type = 'cz.cyberrange.platform.events.trainings.LevelCompleted'`,
+        ));
+    });
+
+    it('CAST timestamp to DATETIME', () => {
+        expect(
+            new QueryBuilder('crczp.events.trainings.*')
+                .select(
+                    field('training_run_id'),
+                    as(cast(field('timestamp'), 'DATETIME'), 'event_time'),
+                )
+                .where(eq('training_run_id', 5))
+                .toSQL(),
+        ).toBe(L(
+            'SELECT training_run_id, CAST(timestamp AS DATETIME) AS event_time',
+            'FROM crczp.events.trainings.*',
+            'WHERE training_run_id = 5',
+        ));
+    });
+
+    it('COUNT(DISTINCT user_ref_id)', () => {
+        expect(
+            new QueryBuilder('crczp.events.trainings.*')
+                .select(
+                    field('training_run_id'),
+                    as(count(field('user_ref_id'), true), 'unique_users'),
+                )
+                .where(eq('type', EventType.LevelStarted))
+                .groupBy(field('training_run_id'))
+                .toSQL(),
+        ).toBe(L(
+            'SELECT training_run_id, COUNT(DISTINCT user_ref_id) AS unique_users',
+            'FROM crczp.events.trainings.*',
+            `WHERE type = 'cz.cyberrange.platform.events.trainings.LevelStarted'`,
+            'GROUP BY training_run_id',
+        ));
+    });
+
+    it('SUM, AVG, MIN, MAX aggregates in one query', () => {
+        expect(
+            new QueryBuilder('crczp.events.trainings.*')
+                .select(
+                    field('training_run_id'),
+                    as(sum(field('actual_score_in_level')), 'total_score'),
+                    as(round(avg(field('actual_score_in_level')), lit(2)), 'avg_score'),
+                    as(min(field('actual_score_in_level')), 'min_score'),
+                    as(max(field('actual_score_in_level')), 'max_score'),
+                )
+                .where(eq('type', EventType.LevelCompleted))
+                .groupBy(field('training_run_id'))
+                .toSQL(),
+        ).toBe(L(
+            'SELECT training_run_id, SUM(actual_score_in_level) AS total_score, ROUND(AVG(actual_score_in_level), 2) AS avg_score, MIN(actual_score_in_level) AS min_score, MAX(actual_score_in_level) AS max_score',
+            'FROM crczp.events.trainings.*',
+            `WHERE type = 'cz.cyberrange.platform.events.trainings.LevelCompleted'`,
+            'GROUP BY training_run_id',
+        ));
+    });
+
+    it('IFNULL to replace NULL hint_title with a default', () => {
+        expect(
+            new QueryBuilder('crczp.events.trainings.*')
+                .select(
+                    field('training_run_id'),
+                    as(fn('IFNULL', field('hint_title'), lit('(no title)')), 'hint_label'),
+                    field('hint_penalty_points'),
+                )
+                .where(eq('type', EventType.HintTaken))
+                .orderBy(field('timestamp'), 'ASC')
+                .toSQL(),
+        ).toBe(L(
+            `SELECT training_run_id, IFNULL(hint_title, '(no title)') AS hint_label, hint_penalty_points`,
+            'FROM crczp.events.trainings.*',
+            `WHERE type = 'cz.cyberrange.platform.events.trainings.HintTaken'`,
+            'ORDER BY timestamp ASC',
+        ));
+    });
+});
+
+// ─── JOINs ───────────────────────────────────────────────────────────────────
+
+describe('JOINs', () => {
+    it('INNER JOIN with ON condition', () => {
+        expect(
+            new QueryBuilder('crczp.events.trainings.*', 'e')
+                .select('*')
+                .join('crczp.runs', 'r', [{ left: 'e.training_run_id', right: 'r.id' }])
+                .where(eq('training_run_id', 42))
+                .toSQL(),
+        ).toBe(L(
+            'SELECT *',
+            'FROM crczp.events.trainings.* e',
+            'JOIN crczp.runs r ON e.training_run_id = r.id',
+            'WHERE training_run_id = 42',
+        ));
+    });
+
+    it('LEFT JOIN with ON condition', () => {
+        expect(
+            new QueryBuilder('crczp.events.trainings.*', 'e')
+                .select('*')
+                .leftJoin('crczp.runs', 'r', [{ left: 'e.training_run_id', right: 'r.id' }])
+                .toSQL(),
+        ).toBe(L(
+            'SELECT *',
+            'FROM crczp.events.trainings.* e',
+            'LEFT JOIN crczp.runs r ON e.training_run_id = r.id',
+        ));
+    });
+
+    it('CROSS JOIN emits no ON clause', () => {
+        expect(
+            new QueryBuilder('crczp.events.trainings.*', 'e')
+                .select('*')
+                .crossJoin('crczp.meta', 'm')
+                .toSQL(),
+        ).toBe(L(
+            'SELECT *',
+            'FROM crczp.events.trainings.* e',
+            'JOIN crczp.meta m',
+        ));
+    });
+});
+
+// ─── clone() independence ─────────────────────────────────────────────────────
+
+describe('clone()', () => {
+    it('clone produces identical SQL', () => {
+        const base = new QueryBuilder('crczp.events.trainings.*')
+            .select(field('training_run_id'), as(count('*'), 'cnt'))
+            .where(eq('type', EventType.LevelCompleted))
+            .groupBy(field('training_run_id'))
+            .limit(50);
+
+        expect(base.clone().toSQL()).toBe(base.toSQL());
+    });
+
+    it('modifying a clone does not affect the original', () => {
+        const base = new QueryBuilder('crczp.events.trainings.*')
+            .select(field('training_run_id'))
+            .where(eq('type', EventType.LevelStarted))
+            .limit(10);
+
+        const fork = base.clone()
+            .andWhere(gt('actual_score_in_level', 50))
+            .limit(5);
+
+        expect(base.toSQL()).toBe(L(
+            'SELECT training_run_id',
+            'FROM crczp.events.trainings.*',
+            `WHERE type = 'cz.cyberrange.platform.events.trainings.LevelStarted'`,
+            'LIMIT 10',
+        ));
+
+        expect(fork.toSQL()).toBe(L(
+            'SELECT training_run_id',
+            'FROM crczp.events.trainings.*',
+            `WHERE (type = 'cz.cyberrange.platform.events.trainings.LevelStarted' AND actual_score_in_level > 50)`,
+            'LIMIT 5',
+        ));
+    });
+});
+
+// ─── Full realistic queries ────────────────────────────────────────────────────
+
+describe('realistic analytics queries', () => {
+    it('top 10 training runs by total score in a time window', () => {
+        expect(
+            new QueryBuilder('crczp.events.trainings.*')
+                .select(
+                    field('training_run_id'),
+                    as(sum(field('actual_score_in_level')), 'total_score'),
+                    as(count('*'), 'levels_completed'),
+                )
+                .where(and(
+                    eq('type', EventType.LevelCompleted),
+                    between('timestamp', 1700000000000, 1800000000000),
+                ))
+                .groupBy(field('training_run_id'))
+                .orderBy(sum(field('actual_score_in_level')), 'DESC')
+                .limit(10)
+                .toSQL(),
+        ).toBe(L(
+            'SELECT training_run_id, SUM(actual_score_in_level) AS total_score, COUNT(*) AS levels_completed',
+            'FROM crczp.events.trainings.*',
+            `WHERE (type = 'cz.cyberrange.platform.events.trainings.LevelCompleted' AND timestamp BETWEEN 1700000000000 AND 1800000000000)`,
+            'GROUP BY training_run_id',
+            'ORDER BY SUM(actual_score_in_level) DESC',
+            'LIMIT 10',
+        ));
+    });
+
+    it('hint usage: users who took more than 3 hints in a run', () => {
+        expect(
+            new QueryBuilder('crczp.events.trainings.*')
+                .select(
+                    field('training_run_id'),
+                    field('user_ref_id'),
+                    as(count('*'), 'hint_count'),
+                    as(sum(field('hint_penalty_points')), 'total_penalty'),
+                )
+                .where(and(
+                    eq('type', EventType.HintTaken),
+                    eq('training_instance_id', 99),
+                ))
+                .groupBy(field('training_run_id'), field('user_ref_id'))
+                .having(gt('hint_count' as any, 3))
+                .orderBy(field('total_penalty' as any), 'DESC')
+                .toSQL(),
+        ).toBe(L(
+            'SELECT training_run_id, user_ref_id, COUNT(*) AS hint_count, SUM(hint_penalty_points) AS total_penalty',
+            'FROM crczp.events.trainings.*',
+            `WHERE (type = 'cz.cyberrange.platform.events.trainings.HintTaken' AND training_instance_id = 99)`,
+            'GROUP BY training_run_id, user_ref_id',
+            'HAVING hint_count > 3',
+            'ORDER BY total_penalty DESC',
+        ));
+    });
+
+    it('distinct users who attempted any answer type in an instance', () => {
+        expect(
+            new QueryBuilder('crczp.events.trainings.*')
+                .select(field('user_ref_id'))
+                .distinct()
+                .where(and(
+                    inList('type', [
+                        EventType.CorrectAnswerSubmitted,
+                        EventType.WrongAnswerSubmitted,
+                        EventType.CorrectFlagSubmitted,
+                        EventType.WrongFlagSubmitted,
+                    ]),
+                    eq('training_instance_id', 5),
+                ))
+                .orderBy(field('user_ref_id'), 'ASC')
+                .toSQL(),
+        ).toBe(L(
+            'SELECT DISTINCT user_ref_id',
+            'FROM crczp.events.trainings.*',
+            `WHERE (type IN ('cz.cyberrange.platform.events.trainings.CorrectAnswerSubmitted', 'cz.cyberrange.platform.events.trainings.WrongAnswerSubmitted', 'cz.cyberrange.platform.events.trainings.CorrectFlagSubmitted', 'cz.cyberrange.platform.events.trainings.WrongFlagSubmitted') AND training_instance_id = 5)`,
+            'ORDER BY user_ref_id ASC',
+        ));
+    });
+
+    it('training run duration for completed runs', () => {
+        expect(
+            new QueryBuilder('crczp.events.trainings.*')
+                .select(
+                    field('training_run_id'),
+                    field('start_time'),
+                    field('end_time'),
+                    as(sub(field('end_time'), field('start_time')), 'duration_ms'),
+                )
+                .where(and(
+                    eq('type', EventType.TrainingRunEnded),
+                    eq('training_instance_id', 12),
+                    isNotNull('end_time'),
+                ))
+                .orderBy(sub(field('end_time'), field('start_time')), 'ASC')
+                .toSQL(),
+        ).toBe(L(
+            'SELECT training_run_id, start_time, end_time, (end_time - start_time) AS duration_ms',
+            'FROM crczp.events.trainings.*',
+            `WHERE (type = 'cz.cyberrange.platform.events.trainings.TrainingRunEnded' AND training_instance_id = 12 AND end_time IS NOT NULL)`,
+            'ORDER BY (end_time - start_time) ASC',
+        ));
+    });
+
+    it('best assessment score per user per level', () => {
+        expect(
+            new QueryBuilder('crczp.events.trainings.*')
+                .select(
+                    field('user_ref_id'),
+                    field('level'),
+                    as(max(field('total_assessment_level_score')), 'best_score'),
+                )
+                .where(and(
+                    eq('type', EventType.LevelCompleted),
+                    eq('level_type', 'ASSESSMENT'),
+                    eq('training_run_id', 77),
+                ))
+                .groupBy(field('user_ref_id'), field('level'))
+                .orderBy(field('level'), 'ASC')
+                .orderBy(max(field('total_assessment_level_score')), 'DESC')
+                .toSQL(),
+        ).toBe(L(
+            'SELECT user_ref_id, level, MAX(total_assessment_level_score) AS best_score',
+            'FROM crczp.events.trainings.*',
+            `WHERE (type = 'cz.cyberrange.platform.events.trainings.LevelCompleted' AND level_type = 'ASSESSMENT' AND training_run_id = 77)`,
+            'GROUP BY user_ref_id, level',
+            'ORDER BY level ASC, MAX(total_assessment_level_score) DESC',
+        ));
+    });
+
+    it('wrong submissions containing a keyword in answer text', () => {
+        expect(
+            new QueryBuilder('crczp.events.trainings.*')
+                .select(field('training_run_id'), field('user_ref_id'), field('answer_content'))
+                .where(and(
+                    inList('type', [EventType.WrongAnswerSubmitted, EventType.WrongFlagSubmitted]),
+                    eq('training_instance_id', 8),
+                    matchQuery('answer_content', 'admin', { boost: 1.5 }),
+                ))
+                .orderBy(field('timestamp'), 'DESC')
+                .limit(50)
+                .toSQL(),
+        ).toBe(L(
+            'SELECT training_run_id, user_ref_id, answer_content',
+            'FROM crczp.events.trainings.*',
+            `WHERE (type IN ('cz.cyberrange.platform.events.trainings.WrongAnswerSubmitted', 'cz.cyberrange.platform.events.trainings.WrongFlagSubmitted') AND training_instance_id = 8 AND MATCH_QUERY(answer_content, 'admin', boost=1.5))`,
+            'ORDER BY timestamp DESC',
+            'LIMIT 50',
+        ));
+    });
+
+    it('paginated event log with LIMIT + OFFSET', () => {
+        expect(
+            new QueryBuilder('crczp.events.trainings.*')
+                .select(field('timestamp'), field('type'), field('training_run_id'), field('user_ref_id'))
+                .where(and(
+                    eq('training_instance_id', 3),
+                    lt('timestamp', 1750000000000),
+                ))
+                .orderBy(field('timestamp'), 'DESC')
+                .limit(25)
+                .offset(75)
+                .toSQL(),
+        ).toBe(L(
+            'SELECT timestamp, type, training_run_id, user_ref_id',
+            'FROM crczp.events.trainings.*',
+            'WHERE (training_instance_id = 3 AND timestamp < 1750000000000)',
+            'ORDER BY timestamp DESC',
+            'LIMIT 75, 25',
+        ));
+    });
+
+    it('time-to-complete per level: TIMESTAMPDIFF between start and end events', () => {
+        expect(
+            new QueryBuilder('crczp.events.trainings.*')
+                .select(
+                    field('training_run_id'),
+                    field('level'),
+                    field('level_type'),
+                    as(fn('TIMESTAMPDIFF', lit('SECOND' as any), field('start_time'), field('end_time')), 'seconds'),
+                )
+                .where(and(
+                    eq('type', EventType.TrainingRunEnded),
+                    eq('training_instance_id', 20),
+                    isNotNull('start_time'),
+                    isNotNull('end_time'),
+                ))
+                .orderBy(field('training_run_id'), 'ASC')
+                .orderBy(field('level'), 'ASC')
+                .toSQL(),
+        ).toBe(L(
+            `SELECT training_run_id, level, level_type, TIMESTAMPDIFF('SECOND', start_time, end_time) AS seconds`,
+            'FROM crczp.events.trainings.*',
+            `WHERE (type = 'cz.cyberrange.platform.events.trainings.TrainingRunEnded' AND training_instance_id = 20 AND start_time IS NOT NULL AND end_time IS NOT NULL)`,
+            'ORDER BY training_run_id ASC, level ASC',
+        ));
+    });
+});

--- a/libs/api/opensearch-query-builder/tsconfig.json
+++ b/libs/api/opensearch-query-builder/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "extends": "../../../tsconfig.base.json",
+    "compilerOptions": {
+        "target": "es2022",
+        "moduleResolution": "bundler",
+        "module": "preserve"
+    },
+"files": [],
+    "include": [],
+    "references": [
+        {
+            "path": "./tsconfig.lib.json"
+        },
+        {
+            "path": "./tsconfig.spec.json"
+        }
+    ]
+}

--- a/libs/api/opensearch-query-builder/tsconfig.lib.json
+++ b/libs/api/opensearch-query-builder/tsconfig.lib.json
@@ -1,0 +1,27 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "outDir": "../../../dist/out-tsc",
+        "declaration": true,
+        "declarationMap": true,
+        "inlineSources": true,
+        "types": []
+    },
+    "exclude": [
+        "src/**/*.spec.ts",
+        "src/test-setup.ts",
+        "jest.config.ts",
+        "src/**/*.test.ts",
+        "vite.config.ts",
+        "vite.config.mts",
+        "vitest.config.ts",
+        "vitest.config.mts",
+        "src/**/*.test.tsx",
+        "src/**/*.spec.tsx",
+        "src/**/*.test.js",
+        "src/**/*.spec.js",
+        "src/**/*.test.jsx",
+        "src/**/*.spec.jsx"
+    ],
+    "include": ["src/**/*.ts"]
+}

--- a/libs/api/opensearch-query-builder/tsconfig.lib.prod.json
+++ b/libs/api/opensearch-query-builder/tsconfig.lib.prod.json
@@ -1,0 +1,9 @@
+{
+    "extends": "./tsconfig.lib.json",
+    "compilerOptions": {
+        "declarationMap": false
+    },
+    "angularCompilerOptions": {
+        "compilationMode": "partial"
+    }
+}

--- a/libs/api/opensearch-query-builder/tsconfig.spec.json
+++ b/libs/api/opensearch-query-builder/tsconfig.spec.json
@@ -1,0 +1,29 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "outDir": "../../../dist/out-tsc",
+        "types": [
+            "vitest/globals",
+            "vitest/importMeta",
+            "vite/client",
+            "node",
+            "vitest"
+        ]
+    },
+    "include": [
+        "vite.config.ts",
+        "vite.config.mts",
+        "vitest.config.ts",
+        "vitest.config.mts",
+        "src/**/*.test.ts",
+        "src/**/*.spec.ts",
+        "src/**/*.test.tsx",
+        "src/**/*.spec.tsx",
+        "src/**/*.test.js",
+        "src/**/*.spec.js",
+        "src/**/*.test.jsx",
+        "src/**/*.spec.jsx",
+        "src/**/*.d.ts"
+    ],
+    "files": ["src/test-setup.ts"]
+}

--- a/libs/api/sandbox-api/src/api/instance/sandbox-instance-api.service.ts
+++ b/libs/api/sandbox-api/src/api/instance/sandbox-instance-api.service.ts
@@ -166,8 +166,7 @@ export class SandboxInstanceApi {
      * @param sandboxUuid id of the sandbox for which remote ssh access is demanded
      */
     getUserSshAccess(sandboxUuid: string): Observable<boolean> {
-        const headers = new HttpHeaders();
-        headers.set('Accept', ['application/octet-stream']);
+        const headers = new HttpHeaders().set('Accept', ['application/octet-stream']);
         return this.http
             .get(`${this.sandboxEndpointUri}/${sandboxUuid}/user-ssh-access`, {
                 responseType: 'blob',

--- a/libs/api/sandbox-api/src/api/pool/pool.api.service.ts
+++ b/libs/api/sandbox-api/src/api/pool/pool.api.service.ts
@@ -354,8 +354,7 @@ export class PoolApi {
      * @param poolId id of a pool
      */
     getManagementSshAccess(poolId: number): Observable<boolean> {
-        const headers = new HttpHeaders();
-        headers.set('Accept', ['application/octet-stream']);
+        const headers = new HttpHeaders().set('Accept', ['application/octet-stream']);
         return this.http
             .get(`${this.apiUrl}/${poolId}/management-ssh-access`, {
                 responseType: 'blob',

--- a/libs/api/training-api/src/api/adaptive-definition/adaptive-definition-default-api.service.ts
+++ b/libs/api/training-api/src/api/adaptive-definition/adaptive-definition-default-api.service.ts
@@ -11,7 +11,7 @@ import {
     TrainingDefinition,
     TrainingDefinitionInfo,
     TrainingDefinitionStateEnum,
-    TrainingPhase,
+    TrainingPhase
 } from '@crczp/training-model';
 import { InfoPhaseDTO } from '../../dto/phase/info-phase/info-phase-dto';
 import { PhaseMapper } from '../../mappers/phase/phase-mapper';
@@ -23,10 +23,7 @@ import { QuestionnairePhaseMapper } from '../../mappers/phase/questionnaire-phas
 import { InfoPhaseMapper } from '../../mappers/phase/info-phase-mapper';
 import { TaskDTO } from '../../dto/phase/training-phase/task-dto';
 import { TaskMapper } from '../../mappers/phase/task-mapper';
-import {
-    ResponseHeaderContentDispositionReader,
-    SentinelParamsMerger,
-} from '@sentinel/common';
+import { ResponseHeaderContentDispositionReader, SentinelParamsMerger } from '@sentinel/common';
 import {
     BlobFileSaver,
     handleJsonError,
@@ -34,7 +31,7 @@ import {
     OffsetPaginatedResource,
     PaginationMapper,
     ParamsBuilder,
-    QueryParam,
+    QueryParam
 } from '@crczp/api-common';
 import { OffsetPaginationEvent } from '@sentinel/common/pagination';
 import { TrainingDefinitionMapper } from '../../mappers/training-definition/training-definition-mapper';
@@ -112,8 +109,9 @@ export class AdaptiveDefinitionDefaultApiService extends AdaptiveTrainingDefinit
     }
 
     download(id: number): Observable<boolean> {
-        const headers = new HttpHeaders();
-        headers.set('Accept', ['application/octet-stream']);
+        const headers = new HttpHeaders().set('Accept', [
+            'application/octet-stream',
+        ]);
 
         return this.http
             .get(
@@ -449,7 +447,6 @@ export class AdaptiveDefinitionDefaultApiService extends AdaptiveTrainingDefinit
 
     private createDefaultHeaders(): HttpHeaders {
         const httpHeaderAccepts: string[] = ['*/*', 'application/json'];
-        const headers = new HttpHeaders().set('Accept', httpHeaderAccepts);
-        return headers;
+        return new HttpHeaders().set('Accept', httpHeaderAccepts);
     }
 }

--- a/libs/api/training-api/src/api/adaptive-instance/adaptive-instance-default-api.service.ts
+++ b/libs/api/training-api/src/api/adaptive-instance/adaptive-instance-default-api.service.ts
@@ -180,8 +180,7 @@ export class AdaptiveInstanceDefaultApi extends AdaptiveTrainingInstanceApi {
      * @param id id of training instance which should be archived
      */
     archive(id: number): Observable<boolean> {
-        const headers = new HttpHeaders();
-        headers.set('Accept', ['application/octet-stream']);
+        const headers = new HttpHeaders().set('Accept', ['application/octet-stream']);
         return this.http
             .get(
                 `${this.trainingExportsEndpointUri}/${this.trainingInstancesUriExtension}/${id}`,

--- a/libs/api/training-api/src/api/cheating-detection-api.service.ts
+++ b/libs/api/training-api/src/api/cheating-detection-api.service.ts
@@ -105,8 +105,7 @@ export class CheatingDetectionApi {
      */
     archive(cheatingDetectionId: number): Observable<any> {
         const filename = `cheating-detection-${cheatingDetectionId}.zip`;
-        const headers = new HttpHeaders();
-        headers.set('Accept', ['application/octet-stream']);
+        const headers = new HttpHeaders().set('Accept', ['application/octet-stream']);
         return this.http
             .get(`${this.apiUrl}/exports/${cheatingDetectionId}`, {
                 responseType: 'blob',

--- a/libs/api/training-api/src/api/definition/training-definition-default-api.service.ts
+++ b/libs/api/training-api/src/api/definition/training-definition-default-api.service.ts
@@ -172,8 +172,7 @@ export class TrainingDefinitionDefaultApi extends LinearTrainingDefinitionApi {
      * @param id id of training definition which should be downloaded
      */
     download(id: number): Observable<boolean> {
-        const headers = new HttpHeaders();
-        headers.set('Accept', ['application/octet-stream']);
+        const headers = new HttpHeaders().set('Accept', ['application/octet-stream']);
 
         return this.http
             .get(
@@ -467,8 +466,7 @@ export class TrainingDefinitionDefaultApi extends LinearTrainingDefinitionApi {
 
     private createDefaultHeaders() {
         const httpHeaderAccepts: string[] = ['*/*', 'application/json'];
-        const headers = new HttpHeaders();
-        headers.set('Accept', httpHeaderAccepts);
+        const headers = new HttpHeaders().set('Accept', httpHeaderAccepts);
         return headers;
     }
 }

--- a/libs/api/training-api/src/api/instance/training-instance-default-api.service.ts
+++ b/libs/api/training-api/src/api/instance/training-instance-default-api.service.ts
@@ -9,7 +9,7 @@ import {
     OffsetPaginatedResource,
     PaginationMapper,
     ParamsBuilder,
-    QueryParam,
+    QueryParam
 } from '@crczp/api-common';
 import { OffsetPaginationEvent } from '@sentinel/common/pagination';
 import { TrainingInstance, TrainingRun } from '@crczp/training-model';
@@ -176,8 +176,9 @@ export class TrainingInstanceDefaultApi extends LinearTrainingInstanceApi {
      * @param id id of training instance which should be archived
      */
     archive(id: number): Observable<boolean> {
-        const headers = new HttpHeaders();
-        headers.set('Accept', ['application/octet-stream']);
+        const headers = new HttpHeaders().set('Accept', [
+            'application/octet-stream',
+        ]);
         return this.http
             .get(
                 `${this.trainingExportsEndpointUri}/${this.trainingInstancesUriExtension}/${id}`,
@@ -217,8 +218,7 @@ export class TrainingInstanceDefaultApi extends LinearTrainingInstanceApi {
     }
 
     exportScore(trainingInstanceId: number): Observable<boolean> {
-        const headers = new HttpHeaders();
-        headers.set('Accept', ['text/plain']);
+        const headers = new HttpHeaders().set('Accept', ['text/plain']);
         return this.http
             .get(
                 `${this.trainingExportsEndpointUri}/${this.trainingInstancesUriExtension}/${trainingInstanceId}/scores`,

--- a/libs/api/user-and-group-api/src/api/user-api.service.ts
+++ b/libs/api/user-and-group-api/src/api/user-api.service.ts
@@ -168,8 +168,7 @@ export class UserApi {
      * Sends http request to get local OIDC users
      */
     getLocalOIDCUsers(): Observable<boolean> {
-        const headers = new HttpHeaders();
-        headers.set('Accept', ['application/octet-stream']);
+        const headers = new HttpHeaders().set('Accept', ['application/octet-stream']);
 
         return this.http
             .get(`${this.apiUrl}/initial-oidc-users`, {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@crczp/platform",
-    "version": "2.4.3",
+    "version": "2.5.6",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@crczp/platform",
-            "version": "2.4.3",
+            "version": "2.5.6",
             "license": "MIT",
             "workspaces": [
                 "./apps/*",
@@ -120,6 +120,23 @@
                 "vitest": "^3.2.0",
                 "zod": "^3.25.0",
                 "zod-class": "^0.0.18"
+            }
+        },
+        "apps/sandbox-designer-ide": {
+            "extraneous": true,
+            "hasInstallScript": true,
+            "workspaces": [
+                "sandbox-designer",
+                "cyberrangecz-theme",
+                "browser-app",
+                "electron-app"
+            ],
+            "devDependencies": {
+                "lerna": "2.4.0"
+            },
+            "engines": {
+                "node": ">=18",
+                "npm": ">=8"
             }
         },
         "node_modules/@acrodata/code-editor": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "license": "MIT",
             "workspaces": [
                 "./apps/*",
-                "./build/libs/*"
+                "./dist/libs/*"
             ],
             "dependencies": {
                 "@acrodata/code-editor": "^0.5.0",
@@ -70,11 +70,11 @@
                 "@nx/esbuild": "^21.6.0",
                 "@nx/eslint": "^21.6.0",
                 "@nx/eslint-plugin": "^21.6.0",
-                "@nx/js": "^21.6.0",
+                "@nx/js": "21.6.10",
                 "@nx/playwright": "^21.6.0",
                 "@nx/plugin": "^21.6.0",
-                "@nx/vite": "^21.6.0",
-                "@nx/web": "^21.6.0",
+                "@nx/vite": "21.6.10",
+                "@nx/web": "21.6.10",
                 "@nx/workspace": "^21.6.0",
                 "@playwright/test": "^1.56.0",
                 "@rdlabo/eslint-plugin-rules": "^21.0.0",
@@ -108,7 +108,7 @@
                 "ng-packagr": "~20.3.0",
                 "nx": "^21.6.0",
                 "postcss": "^8.5.0",
-                "postcss-url": "~10.1.0",
+                "postcss-url": "~10.1.3",
                 "prettier": "^3.6.0",
                 "ts-node": "^10.9.0",
                 "tslib": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@crczp/platform",
-    "version": "2.5.5",
+    "version": "2.5.6",
     "license": "MIT",
     "private": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -61,11 +61,11 @@
         "@nx/esbuild": "^21.6.0",
         "@nx/eslint": "^21.6.0",
         "@nx/eslint-plugin": "^21.6.0",
-        "@nx/js": "^21.6.0",
+        "@nx/js": "21.6.10",
         "@nx/playwright": "^21.6.0",
         "@nx/plugin": "^21.6.0",
-        "@nx/vite": "^21.6.0",
-        "@nx/web": "^21.6.0",
+        "@nx/vite": "21.6.10",
+        "@nx/web": "21.6.10",
         "@nx/workspace": "^21.6.0",
         "@playwright/test": "^1.56.0",
         "@rdlabo/eslint-plugin-rules": "^21.0.0",
@@ -99,7 +99,7 @@
         "ng-packagr": "~20.3.0",
         "nx": "^21.6.0",
         "postcss": "^8.5.0",
-        "postcss-url": "~10.1.0",
+        "postcss-url": "~10.1.3",
         "prettier": "^3.6.0",
         "ts-node": "^10.9.0",
         "tslib": "^2.3.0",
@@ -132,6 +132,6 @@
     },
     "workspaces": [
         "./apps/*",
-        "./build/libs/*"
+        "./dist/libs/*"
     ]
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -14,10 +14,7 @@
             "defaultCategory": "warning"
         }
     },
-    "exclude": [
-        "node_modules",
-        "tmp"
-    ],
+    "exclude": ["node_modules", "tmp"],
     "compileOnSave": false,
     "compilerOptions": {
         "baseUrl": ".",
@@ -27,25 +24,14 @@
         "importHelpers": true,
         "incremental": true,
         "tsBuildInfoFile": ".angular/cache/.tsbuildinfo",
-        "lib": [
-            "es2020",
-            "dom"
-        ],
+        "lib": ["es2020", "dom"],
         "module": "esnext",
         "moduleResolution": "node",
         "paths": {
-            "@crczp/api-common": [
-                "libs/api/api-common/src/index.ts"
-            ],
-            "@crczp/components": [
-                "libs/components/src/index.ts"
-            ],
-            "@crczp/mixins": [
-                "libs/mixins/src/index.ts"
-            ],
-            "@crczp/routing-commons": [
-                "libs/utils/routing/src/index.ts"
-            ],
+            "@crczp/api-common": ["libs/api/api-common/src/index.ts"],
+            "@crczp/components": ["libs/components/src/index.ts"],
+            "@crczp/mixins": ["libs/mixins/src/index.ts"],
+            "@crczp/routing-commons": ["libs/utils/routing/src/index.ts"],
             "@crczp/sandbox-agenda": [
                 "libs/agenda/sandbox-agenda/src/index.ts"
             ],
@@ -82,12 +68,8 @@
             "@crczp/sandbox-agenda/sandbox-topology": [
                 "libs/agenda/sandbox-agenda/sandbox-topology/index.ts"
             ],
-            "@crczp/sandbox-api": [
-                "libs/api/sandbox-api/src/index.ts"
-            ],
-            "@crczp/sandbox-model": [
-                "libs/model/sandbox-model/src/index.ts"
-            ],
+            "@crczp/sandbox-api": ["libs/api/sandbox-api/src/index.ts"],
+            "@crczp/sandbox-model": ["libs/model/sandbox-model/src/index.ts"],
             "@crczp/training-agenda": [
                 "libs/agenda/training-agenda/src/index.ts"
             ],
@@ -193,12 +175,8 @@
             "@crczp/training-agenda/run-results": [
                 "libs/agenda/training-agenda/run-results/index.ts"
             ],
-            "@crczp/training-api": [
-                "libs/api/training-api/src/index.ts"
-            ],
-            "@crczp/training-model": [
-                "libs/model/training-model/src/index.ts"
-            ],
+            "@crczp/training-api": ["libs/api/training-api/src/index.ts"],
+            "@crczp/training-model": ["libs/model/training-model/src/index.ts"],
             "@crczp/user-and-group-agenda": [
                 "libs/agenda/user-and-group-agenda/src/index.ts"
             ],
@@ -232,9 +210,7 @@
             "@crczp/user-and-group-model": [
                 "libs/model/user-and-group-model/src/index.ts"
             ],
-            "@crczp/utils": [
-                "libs/utils/misc/src/index.ts"
-            ],
+            "@crczp/utils": ["libs/utils/misc/src/index.ts"],
             "@crczp/visualization-api": [
                 "libs/api/visualization-api/src/index.ts"
             ],
@@ -244,14 +220,12 @@
             "@crczp/visualization-model": [
                 "libs/model/visualization-model/src/index.ts"
             ],
-            "@crczp/visualization/api": [
-                "lib/api/walkthrough-api/src/index.ts"
-            ]
+            "@crczp/visualization/api": ["lib/api/walkthrough-api/src/index.ts"]
         },
         "rootDir": ".",
         "skipDefaultLibCheck": true,
         "skipLibCheck": true,
         "sourceMap": true,
         "target": "es2015"
-    },
+    }
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -31,6 +31,9 @@
             "@crczp/api-common": ["libs/api/api-common/src/index.ts"],
             "@crczp/components": ["libs/components/src/index.ts"],
             "@crczp/mixins": ["libs/mixins/src/index.ts"],
+            "@crczp/opensearch-query-builder": [
+                "libs/api/opensearch-query-builder/src/index.ts"
+            ],
             "@crczp/routing-commons": ["libs/utils/routing/src/index.ts"],
             "@crczp/sandbox-agenda": [
                 "libs/agenda/sandbox-agenda/src/index.ts"


### PR DESCRIPTION
This PR implements event querying via SQL in OpenSearch 

For writing the queries a QueryBuilder has been added. This module can be built and exported as a library and potentially provided alongside the platform. This way external users can write TS scripts to query their own desired data from the backend.